### PR TITLE
fix: vulnerable_dependencies are expected in the dataFrame

### DIFF
--- a/src/cve/pipeline/input.py
+++ b/src/cve/pipeline/input.py
@@ -235,6 +235,10 @@ def build_input(pipe: LinearPipeline, config: Config, run_config: RunConfig):
     @stage
     def check_vulnerable_dependencies(message: AgentMorpheusEngineInput) -> AgentMorpheusEngineInput:
         """Check for vulnerable packages in the dependency graph and update the message object."""
+        if not run_config.general.use_dependency_checker:
+            message.info.vulnerable_dependencies = [VulnerableDependencies(
+                vuln_id=cve_intel.cve_id, vuln_package_intel_sources=[], vulnerable_sbom_packages=[]) for cve_intel in message.info.intel]
+            return message
 
         sbom = message.info.sbom.packages
         image = f"{message.input.image.name}:{message.input.image.tag}"
@@ -307,8 +311,7 @@ def build_input(pipe: LinearPipeline, config: Config, run_config: RunConfig):
         message.info.vulnerable_dependencies = asyncio.run(_inner())
         return message
 
-    if run_config.general.use_dependency_checker:
-        pipe.add_stage(check_vulnerable_dependencies(config))
+    pipe.add_stage(check_vulnerable_dependencies(config))
 
     if run_config.input.type != 'http':
         @stage


### PR DESCRIPTION
Fix #4 

The whole pipeline is tightly coupled to the `vulnerable_dependencies` attribute in the `message.info` so the easiest way to bypass all the places where it is used is by providing an empty `list[VulnerableDependencies]`