### PR TITLE
fix: ensure agent checks for vulnerable functions/methods if mentioned in CVE

### DIFF
--- a/src/cve/nodes/cve_checklist_node.py
+++ b/src/cve/nodes/cve_checklist_node.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 cve_prompt1 = (
     MOD_FEW_SHOT.format(examples=get_mod_examples())
     + additional_intel_prompting
+    + "\n\nIf a vulnerable function or method is mentioned in the CVE description, ensure the first checklist item verifies whether this function or method is being called from the code or used by the code."
     + "\nThe vulnerable version of the vulnerable package is already verified to be installed within the container. Check only the other factors that affect exploitability, no need to verify version again."
 )
 


### PR DESCRIPTION
Agent went from not checking for vulnerable method at all, which is clearly mentioned in the CVE description and summary, to checking and correctly concluding that the vulnerable method is not used in the input code base.

Example CVE: [CVE-2024-1485](https://access.redhat.com/security/cve/CVE-2024-1485)
"summary": "registry-support: decompress can delete files outside scope via relative paths",
"description": "A vulnerability was found in the decompression function of registry-support. This issue can be triggered by an unauthenticated remote attacker when tricking a user into opening a specially modified .tar archive, leading to the cleanup process following relative paths to overwrite or delete files outside the intended scope."

Fixed result:
Checklist item 1:
Q: Verify Decompression Function Usage: Check if the decompression function of registry-support is being used within the containerized application. Specifically, look for any calls to this function when handling .tar archives or devfiles that use the `parent` or `plugin` keywords.

A: No, the decompression function of registry-support is not being used within the containerized application when handling .tar archives or devfiles with `parent` or `plugin` keywords.