### PR TITLE
fix: nvd Authentication + Authorization via NginX

### DIFF
--- a/kustomize/base/agent_morpheus-RH.yaml
+++ b/kustomize/base/agent_morpheus-RH.yaml
@@ -85,6 +85,8 @@ spec:
               value: http://nginx-cache:8080/nim_embed/v1
             - name: NVD_BASE_URL
               value: http://nginx-cache:8080/nvd
+            - name: NVD_API_KEY_HEADER
+              value: api-key
             - name: NVIDIA_API_BASE
               value: http://nginx-cache:8080/nim_llm/v1
             - name: OPENAI_API_BASE

--- a/kustomize/base/nginx/templates/routes/intel.conf.template
+++ b/kustomize/base/nginx/templates/routes/intel.conf.template
@@ -13,6 +13,7 @@ location /serpapi {
 location /nvd {
     rewrite ^\/nvd(\/.*)$ /rest$1 break;
     proxy_pass https://services.nvd.nist.gov;
+    proxy_set_header ApiKey $nvd_http_api_key;
     proxy_cache intel_cache;
     proxy_cache_valid 200 202 365d;
     proxy_cache_methods GET;

--- a/kustomize/base/nginx/templates/variables/template-variables.conf.template
+++ b/kustomize/base/nginx/templates/variables/template-variables.conf.template
@@ -48,10 +48,7 @@ map $http_authorization $ghsa_http_authorization {
    default $http_authorization;
 }
 
-map $http_authorization $nvd_http_authorization {
-   'Bearer AGENT_MORPHEUS' 'Bearer ${NVD_API_KEY}';
-   'Bearer "AGENT_MORPHEUS"' 'Bearer ${NVD_API_KEY}';
-   'Bearer CYBER_DEV_DAY' 'Bearer ${NVD_API_KEY}';
-   'Bearer "CYBER_DEV_DAY"' 'Bearer ${NVD_API_KEY}';
-   default $http_authorization;
+map $http_apiKey $nvd_http_api_key {
+  'AGENT_MORPHEUS' '${NVD_API_KEY}';
 }
+

--- a/src/cve/utils/clients/nvd_client.py
+++ b/src/cve/utils/clients/nvd_client.py
@@ -27,6 +27,8 @@ from ..intel_utils import parse
 from ..url_utils import url_join
 from .intel_client import IntelClient
 
+API_KEY_HEADER_NAME = os.environ.get("NVD_API_KEY_HEADER") if os.environ.get("NVD_API_KEY_HEADER") else "apiKey"
+
 logger = logging.getLogger(f"morpheus.{__name__}")
 
 
@@ -75,7 +77,7 @@ class NVDClient(IntelClient):
         self._headers = {'Content-Type': 'application/json'}
 
         if self._api_key is not None:
-            self._headers['apiKey'] = self._api_key
+            self._headers[API_KEY_HEADER_NAME] = self._api_key
 
     @classmethod
     def default_base_url(cls) -> str:


### PR DESCRIPTION
NVD returns weird 404 or 503  http status code if the `apiKey` header contains invalid value.
current ( until now) NginX configuration tried to propagate `Authorization` header , which is irrelevant ( because `nvd` expects `apiKey` instead of Authorization, and agent morpheus also sends in the request the `apiKey` Header).
Then in NGINX config,  I've mapped the dummy `AGENT_MORPHEUS ` placeholder to the real NVD API KEY value stored in environment variable. But it appears that NginX cannot handle/process correctly  request headers  that their name is only in camel case, thus i had to change the header name sent from agent-morpheus to `api-key` ( instead of `apiKey`)  and that did the trick.