### PR TITLE
fix: add explicit docker format for container building

### DIFF
--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -100,6 +100,7 @@ spec:
               --label=agent_morpheus_vcs_branch={{source_branch}}
               --label=agent_morpheus_vcs_build_commit_id={{revision}}
               --label=agent_morpheus_vcs_repo={{repo_url}}
+              --format=docker
         taskRef:
           resolver: cluster
           params:

--- a/.tekton/on-push.yaml
+++ b/.tekton/on-push.yaml
@@ -94,6 +94,7 @@ spec:
               --label=agent_morpheus_vcs_branch={{source_branch}}
               --label=agent_morpheus_vcs_build_commit_id={{revision}}
               --label=agent_morpheus_vcs_repo={{repo_url}}
+              --format=docker
         taskRef:
           resolver: cluster
           params:

--- a/.tekton/on-tag.yaml
+++ b/.tekton/on-tag.yaml
@@ -122,6 +122,7 @@ spec:
               --label=agent_morpheus_vcs_branch={{source_branch}}
               --label=agent_morpheus_vcs_build_commit_id={{revision}}
               --label=agent_morpheus_vcs_repo={{repo_url}}
+              --format=docker
         taskRef:
           resolver: cluster
           params:


### PR DESCRIPTION
The [current](https://github.com/openshift-pipelines/task-containers/blob/main/scripts/buildah-bud.sh) `buildah` task doesn't parse the FORMAT parameter.
Added explicit build argument `--format-docker`