### PR TITLE
chore: deploy with right cname

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -38,27 +38,33 @@ client-secret=some-long-secret-used-by-the-oauth-client
 openshift-domain=$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')
 EOF
 ```
+6. Transplant right service CNAME according to auto generated certificate
+```shell
+export CALLBACK_URL=https:\\/\\/$(echo agent-morpheus-client.$(oc projects | grep "*" | awk -F '* ' '{print $2}').svc:8443)
+find . | grep agent-morpheus-config.json | xargs -i sed -i "s/CALLBACK_URL_PLACEHOLDER/$CALLBACK_URL/g" {}
 
-6. Deploy agent-morpheus + agent-morpheus-client to your namespace. The default configuration will use local embeddings and remote NIM LLM
+
+```
+7. Deploy agent-morpheus + agent-morpheus-client to your namespace. The default configuration will use local embeddings and remote NIM LLM
 ```shell
 oc kustomize base |  oc apply -f - -n $YOUR_NAMESPACE_NAME
 ```
 
-7. Alternatively, if you want to deploy agent-morpheus with our self-hosted LLM or fully remote services, then run
+8. Alternatively, if you want to deploy agent-morpheus with our self-hosted LLM or fully remote services, then run
 ```shell
 # Deploy agent morpheus with local llama3.1 LLM 
 oc kustomize overlays/local-llama3.1-70b-4bit |  oc apply -f - -n $YOUR_NAMESPACE_NAME
 # Deploy agent morpheus with remote llama-3.1-70b-4bit LLM
 oc kustomize overlays/remote-nim-all |  oc apply -f - -n $YOUR_NAMESPACE_NAME
 ```
-8. If you didn't deploy yet self-hosted embedding model and one of the above LLMs, first fetch latest version of agent-morpheus git submodule
+9. If you didn't deploy yet self-hosted embedding model and one of the above LLMs, first fetch latest version of agent-morpheus git submodule
 ```shell
 git submodule init --recursive
 git submodule update --merge --recursive
 # Or if the local submodule sha is not updated to latest one, you can fetch it from remote tracking branch
 git submodule update --remote --merge --recursive
 ```
-9. Follow the instructions below
+10. Follow the instructions below
     1. from your local repository
        ```shell
        cd ../agent-morpheus-models    
@@ -66,7 +72,7 @@ git submodule update --remote --merge --recursive
        [open instructions locally](../agent-morpheus-models/README.md)
    2. [Open instruction in browser](https://github.com/RHEcosystemAppEng/agent-morpheus-models)
 
-10. Create the OAuthClient with the same secret and using the generated route
+11. Create the OAuthClient with the same secret and using the generated route
 
 ```bash
 oc apply -f - <<EOF
@@ -89,17 +95,17 @@ agent morpheus, enabling testing rapidly changes in agent-morpheus on cluster, w
 This overlay enforce invoking the LLM on every invocation, in order to guarantee that every change will propagate to LLM and will
 cause the LLM to produce a different output, and not cached version output from the llm cache in nginx.
 
-9. Perform Steps 1-3 On a new namespace
-10. For enabling LANGSMITH traces ( very useful for debugging), input your Langchain API Key:
+12. Perform Steps 1-3 On a new namespace
+13. For enabling LANGSMITH traces ( very useful for debugging), input your Langchain API Key:
 ```shell
  echo "langchainApiKey=YOUR_API_KEY_GOES_HERE" > overlays/developer/langsmith-secret.env
 ```
-11. Deploy agent-morpheus developer mode
+14. Deploy agent-morpheus developer mode
 ```shell
 kustomize build overlays/developer/  | oc apply -f -
 ```
 
-12. Run Agent morpheus first time and verify it's working ( in a new terminal `agent-morpheus`)
+15. Run Agent morpheus first time and verify it's working ( in a new terminal `agent-morpheus`)
 ```shell
 # enter agent morpheus pod in a new bash shell process
 oc exec -it $(oc get pods -o=name -l component=agent-morpheus-rh ) -- bash
@@ -154,20 +160,20 @@ Source: 0 messages [00:13, ? messages/s]
 LLM: 0 messages [00:13, ? messages/s]
 ```
 
-13. Change something in agent-morpheus, and make sure that it's the only change appears, to make sure that irrelevant changes won't intrude into the pod before testing
+16. Change something in agent-morpheus, and make sure that it's the only change appears, to make sure that irrelevant changes won't intrude into the pod before testing
 ```shell
 git diff
 ```
 Expected Output example:
 ![img.png](img.png)
 
-14. Now, That you're seeing your modification, and this is what you want to test in cluster,
+17. Now, That you're seeing your modification, and this is what you want to test in cluster,
     synchronize agent morpheus pod with agent-morpheus repo, to copy all changes from your local git worktree/index to the agent-morpheus-rh pod
 ```shell
 # you must be in some path in the repo so it will work
  oc rsync $(git rev-parse --show-toplevel)/ $(oc get pods -o=name -l component=agent-morpheus-rh ):.
 ```
-15. Now, after fix/feature propagated completely to the pod, go back the terminal windows `agent-morpheus` ( from section 12), and press CTRL + C shortcut to gracefully shut down agent-morpheus.
+18. Now, after fix/feature propagated completely to the pod, go back the terminal windows `agent-morpheus` ( from section 12), and press CTRL + C shortcut to gracefully shut down agent-morpheus.
 Expected output:
 ```shell
 Stopping pipeline. Please wait... Press Ctrl+C again to kill.
@@ -180,14 +186,14 @@ LLM[Complete]: 0 messages [00:00, ? messages/s]
 Total time: 701.99 sec
 Pipeline runtime: 694.18 sec
 ```
-16. In the same shell, Run again agent-morpheus in order to take new changes in pod' container filesystem
+19. In the same shell, Run again agent-morpheus in order to take new changes in pod' container filesystem
 ```shell
 eval $AGENT_MORPHEUS_PYTHON_COMMAND
 ```
 OK, Now you're ready to send requests ( manually or using agent-morpheus-client) in order to test your fix/feature!.
-Pay attention, now every subsequent change that you'd like to test, requires you only to repeat steps 13-16( including the coding itself, done very quickly) 
+Pay attention, now every subsequent change that you'd like to test, requires you only to repeat steps 16-19( including the coding itself, done very quickly) 
 
-17. When finishing, and wants to save resources, clean up:
+20. When finishing, and wants to save resources, clean up:
 ```shell
 # Delete all resources but keep all data saved in PVCs
 kustomize build overlays/developer/  | oc delete -l purpose!=persistent -f -

--- a/kustomize/base/agent-morpheus-config.json
+++ b/kustomize/base/agent-morpheus-config.json
@@ -68,7 +68,7 @@
   "output": {
     "_type": "http",
     "endpoint": "/reports",
-    "url": "https://agent-morpheus-client.svc:8443",
+    "url": "CALLBACK_URL_PLACEHOLDER",
     "authentication": {
       "_type": "bearer",
       "token_path": "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/kustomize/overlays/local-llama3.1-70b-4bit/agent-morpheus-config.json
+++ b/kustomize/overlays/local-llama3.1-70b-4bit/agent-morpheus-config.json
@@ -71,7 +71,7 @@
   "output": {
     "_type": "http",
     "endpoint": "/reports",
-    "url": "https://agent-morpheus-client.svc:8443",
+    "url": "CALLBACK_URL_PLACEHOLDER",
     "authentication": {
       "_type": "bearer",
       "token_path": "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/kustomize/overlays/remote-nim-all/agent-morpheus-config.json
+++ b/kustomize/overlays/remote-nim-all/agent-morpheus-config.json
@@ -71,7 +71,7 @@
   "output": {
     "_type": "http",
     "endpoint": "/reports",
-    "url": "https://agent-morpheus-client.svc:8443",
+    "url": "CALLBACK_URL_PLACEHOLDER",
     "authentication": {
       "_type": "bearer",
       "token_path": "/var/run/secrets/kubernetes.io/serviceaccount/token"


### PR DESCRIPTION
Service CA operator Creates certificate + private key signed pair with hostname according to service name concatenated with ".namespace".

Need to automate deployment with the process of "transplanting this right service hostname CNAME ( that is signed within the certificate) into agent morpheus configuration