### PR TITLE
chore: update agent morpheus queue settings

### DIFF
--- a/kustomize/base/agent_morpheus_client.yaml
+++ b/kustomize/base/agent_morpheus_client.yaml
@@ -102,6 +102,10 @@ spec:
     port: 8443
     protocol: TCP
     targetPort: 8443
+  - name: metrics
+    protocol: TCP
+    port: 9000
+    targetPort: 9000
   selector:
     app: agent-morpheus
     component: agent-morpheus-client
@@ -121,3 +125,18 @@ spec:
   to:
     kind: Service
     name: agent-morpheus-client
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: agent-morpheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /q/metrics
+      port: metrics
+      scheme: http
+  selector:
+    matchLabels:
+      app: agent-morpheus
+      component: agent-morpheus-client

--- a/kustomize/overlays/batch-processing/kustomization.yaml
+++ b/kustomize/overlays/batch-processing/kustomization.yaml
@@ -28,7 +28,7 @@ patchesStrategicMerge:
               image: quay.io/ecosystem-appeng/agent-morpheus-rh:latest
               imagePullPolicy: Always
               workingDir: /workspace/
-    #          Deploy wity QoS
+              # Deploy with QoS(Guaranteed)
               resources:
                 limits:
                   memory: "12Gi"
@@ -37,7 +37,7 @@ patchesStrategicMerge:
                 requests:
                   memory: "12Gi"
                   cpu: "1000m"
-                  nvidia.com/gpu: "1"              
+                  nvidia.com/gpu: "1"
   - |-
     apiVersion: apps/v1
     kind: Deployment
@@ -68,11 +68,9 @@ patchesStrategicMerge:
               imagePullPolicy: Always
               env:
                 - name: MORPHEUS_QUEUE_TIMEOUT
-                  value: 20m
-                
+                  value: 60m
                 - name: MORPHEUS_QUEUE_MAX_ACTIVE
-                  value: "3"
-    
+                  value: "5"
 
 configMapGenerator:
   - behavior: replace


### PR DESCRIPTION
- Add a `ServiceMonitor` resource to enable metrics scraping.
- Update the `Service` definition to expose the `metrics` port.
- Increase the values of `MORPHEUS_QUEUE_TIMEOUT` and `MORPHEUS_QUEUE_MAX_ACTIVE` to support higher concurrency for query execution.