### PR TITLE
docs: Add supported ecosystems section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ limitations under the License.
 - [Target audience](#target-audience)
 - [Prerequisites](#prerequisites)
 - [Hardware requirements](#hardware-requirements)
+- [Supported Ecosystems](#suppored-ecosystems)
 - [API definition](#api-definition)
 - [Use case description](#use-case-description)
   - [How it works](#how-it-works)
@@ -110,6 +111,16 @@ The overall hardware requirements depend on selected pipeline configuration. At 
   - The pipeline can share the GPU with the LLM NIM, but it is recommended to have a separate GPU for the LLM NIM for optimal performance.
 - **(Optional) Embedding NIM**: [NV-EmbedQA-E5-v5 Support Matrix](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/support-matrix.html#nv-embedqa-e5-v5)
   - The pipeline can share the GPU with the Embedding NIM, but it is recommended to have a separate GPU for the Embedding NIM for optimal performance.
+
+
+## Supported Ecosystems
+      
+| Ecosystem       | Source Code Analysis | Transitive Analysis | Ecosystem Type  |
+| --------------- | -------------------- | ------------------- | --------------- |
+| Python          | &check;              | &cross;             | pypi            |
+| Golang          | &check;              | &check;             | go              |
+| Java            | &check;              | &cross;             | maven           |
+| JavaScript/Node | &check;              | &cross;             | npm             |
 
 
 ## API definition
@@ -896,3 +907,5 @@ By using this software or microservice, you are agreeing to the  [terms and cond
 GOVERNING TERMS: The NIM container is governed by the [NVIDIA Software License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/) and [Product-Specific Terms for AI Products](https://www.nvidia.com/en-us/agreements/enterprise-software/product-specific-terms-for-ai-products/); and use of this model is governed by the [NVIDIA AI Foundation Models Community License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-ai-foundation-models-community-license-agreement/).
 
 ADDITIONAL Terms: [Meta Llama 3.1 Community License](https://www.llama.com/llama3_1/license/), Built with Meta Llama 3.1.
+
+


### PR DESCRIPTION
Added a section header "supported ecosystems" to specify the currently supported ecosystem by agent Morpheus Redhat version