### PR TITLE
fix: exception in function-name-extractor

### DIFF
--- a/src/cve/utils/tools.py
+++ b/src/cve/utils/tools.py
@@ -262,14 +262,14 @@ returns list of calling functions in the package, e.g - ['packageName,functionNa
         if len(the_final_package) > 0 and the_final_package[0] != package:
             package = the_final_package[0]
 
-        if function.__contains__(".") and "(" or ")" in function:
+        if function.__contains__(".") and function.__contains__("(") and function.__contains__(")"):
             function_string = str(function)
             function_prefix_index_end = function_string.find("(") + 1
             function_ending_index_end = function_string.rfind(")")
             function_builder = traverse_all_parameters(function_ending_index_end, function_prefix_index_end
                                                        , function_string)
         else:
-            return [query]
+            return []
 
         containing_functions = list()
         comment_line_character = self.lang_parser.get_comment_line_notation()


### PR DESCRIPTION
when input doesn't contain a certain usage of a function