### PR TITLE
ci: fix and improve image' build and push speed

### DIFF
--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -95,7 +95,8 @@ spec:
           - name: BUILD_EXTRA_ARGS
             value: >-
               --target base
-              --squash
+              --layers
+              --cache-to quay.io/ecosystem-appeng/agent-morpheus-rh
               --label=quay.expires-after=$(params.image-expires-after)
               --label=agent_morpheus_vcs_branch={{source_branch}}
               --label=agent_morpheus_vcs_build_commit_id={{revision}}

--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -97,6 +97,7 @@ spec:
               --target base
               --layers
               --cache-to quay.io/ecosystem-appeng/agent-morpheus-rh
+              --cache-from quay.io/ecosystem-appeng/agent-morpheus-rh
               --label=quay.expires-after=$(params.image-expires-after)
               --label=agent_morpheus_vcs_branch={{source_branch}}
               --label=agent_morpheus_vcs_build_commit_id={{revision}}

--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -139,9 +139,9 @@ spec:
            - ReadWriteOnce
          resources:
            requests:
-             storage: 30Gi
-           limits:
              storage: 60Gi
+           limits:
+             storage: 90Gi
 
   -  name: buildah-temp-cache
      volumeClaimTemplate:
@@ -150,9 +150,9 @@ spec:
            - ReadWriteOnce
          resources:
            requests:
-             storage: 30Gi
-           limits:
              storage: 60Gi
+           limits:
+             storage: 90Gi
   # This workspace will inject secret to help the git-clone task to be able to
   # checkout the private repositories
   - name: basic-auth

--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -97,7 +97,6 @@ spec:
               --target base
               --layers
               --cache-to quay.io/ecosystem-appeng/agent-morpheus-rh
-              --cache-from quay.io/ecosystem-appeng/agent-morpheus-rh
               --label=quay.expires-after=$(params.image-expires-after)
               --label=agent_morpheus_vcs_branch={{source_branch}}
               --label=agent_morpheus_vcs_build_commit_id={{revision}}
@@ -134,26 +133,12 @@ spec:
           requests:
             storage: 1Gi
   -  name: buildah-storage-dir
-     volumeClaimTemplate:
-       spec:
-         accessModes:
-           - ReadWriteOnce
-         resources:
-           requests:
-             storage: 150Gi
-           limits:
-             storage: 150Gi
+     persistentVolumeClaim:
+       claimName: pvc-buildah-storage
 
   -  name: buildah-temp-cache
-     volumeClaimTemplate:
-       spec:
-         accessModes:
-           - ReadWriteOnce
-         resources:
-           requests:
-             storage: 60Gi
-           limits:
-             storage: 90Gi
+     persistentVolumeClaim:
+       claimName: pvc-buildah-temp-storage
   # This workspace will inject secret to help the git-clone task to be able to
   # checkout the private repositories
   - name: basic-auth

--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -139,9 +139,9 @@ spec:
            - ReadWriteOnce
          resources:
            requests:
-             storage: 60Gi
+             storage: 150Gi
            limits:
-             storage: 90Gi
+             storage: 150Gi
 
   -  name: buildah-temp-cache
      volumeClaimTemplate:

--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -119,6 +119,9 @@ spec:
 
           - name: buildah-storage-dir
             workspace: buildah-storage-dir
+
+          - name: buildah-temp-cache
+            workspace: buildah-temp-cache
   workspaces:
   - name: source
     volumeClaimTemplate:
@@ -129,6 +132,17 @@ spec:
           requests:
             storage: 1Gi
   -  name: buildah-storage-dir
+     volumeClaimTemplate:
+       spec:
+         accessModes:
+           - ReadWriteOnce
+         resources:
+           requests:
+             storage: 30Gi
+           limits:
+             storage: 60Gi
+
+  -  name: buildah-temp-cache
      volumeClaimTemplate:
        spec:
          accessModes:

--- a/.tekton/on-push.yaml
+++ b/.tekton/on-push.yaml
@@ -134,9 +134,9 @@ spec:
            - ReadWriteOnce
          resources:
            requests:
-             storage: 60Gi
+             storage: 150Gi
            limits:
-             storage: 90Gi
+             storage: 150Gi
 
   -  name: buildah-temp-cache
      volumeClaimTemplate:

--- a/.tekton/on-push.yaml
+++ b/.tekton/on-push.yaml
@@ -113,6 +113,10 @@ spec:
 
           - name: buildah-storage-dir
             workspace: buildah-storage-dir
+
+          - name: buildah-temp-cache
+            workspace: buildah-temp-cache
+
   workspaces:
   - name: source
     volumeClaimTemplate:
@@ -132,6 +136,20 @@ spec:
              storage: 30Gi
            limits:
              storage: 60Gi
+
+  -  name: buildah-temp-cache
+     volumeClaimTemplate:
+       spec:
+         accessModes:
+           - ReadWriteOnce
+         resources:
+           requests:
+             storage: 30Gi
+           limits:
+             storage: 60Gi
+
+
+
   # This workspace will inject secret to help the git-clone task to be able to
   # checkout the private repositories
   - name: basic-auth

--- a/.tekton/on-push.yaml
+++ b/.tekton/on-push.yaml
@@ -90,7 +90,8 @@ spec:
           - name: BUILD_EXTRA_ARGS
             value: >-
               --target base
-              --squash
+              --layers
+              --cache-to quay.io/ecosystem-appeng/agent-morpheus-rh              
               --label=agent_morpheus_vcs_branch={{source_branch}}
               --label=agent_morpheus_vcs_build_commit_id={{revision}}
               --label=agent_morpheus_vcs_repo={{repo_url}}
@@ -133,9 +134,9 @@ spec:
            - ReadWriteOnce
          resources:
            requests:
-             storage: 30Gi
-           limits:
              storage: 60Gi
+           limits:
+             storage: 90Gi
 
   -  name: buildah-temp-cache
      volumeClaimTemplate:
@@ -144,9 +145,9 @@ spec:
            - ReadWriteOnce
          resources:
            requests:
-             storage: 30Gi
-           limits:
              storage: 60Gi
+           limits:
+             storage: 90Gi
 
 
 

--- a/.tekton/on-tag.yaml
+++ b/.tekton/on-tag.yaml
@@ -161,9 +161,9 @@ spec:
            - ReadWriteOnce
          resources:
            requests:
-             storage: 30Gi
+             storage: 150Gi
            limits:
-             storage: 60Gi
+             storage: 150Gi
 
   -  name: buildah-temp-cache
      volumeClaimTemplate:
@@ -172,9 +172,9 @@ spec:
            - ReadWriteOnce
          resources:
            requests:
-             storage: 30Gi
-           limits:
              storage: 60Gi
+           limits:
+             storage: 90Gi
   # This workspace will inject secret to help the git-clone task to be able to
   # checkout the private repositories
   - name: basic-auth

--- a/.tekton/on-tag.yaml
+++ b/.tekton/on-tag.yaml
@@ -141,6 +141,10 @@ spec:
 
           - name: buildah-storage-dir
             workspace: buildah-storage-dir
+
+          - name: buildah-temp-cache
+            workspace: buildah-temp-cache
+
   workspaces:
   - name: source
     volumeClaimTemplate:
@@ -151,6 +155,17 @@ spec:
           requests:
             storage: 1Gi
   -  name: buildah-storage-dir
+     volumeClaimTemplate:
+       spec:
+         accessModes:
+           - ReadWriteOnce
+         resources:
+           requests:
+             storage: 30Gi
+           limits:
+             storage: 60Gi
+
+  -  name: buildah-temp-cache
      volumeClaimTemplate:
        spec:
          accessModes:

--- a/.tekton/pvcs/buildah-containers-storage-pvc.yaml
+++ b/.tekton/pvcs/buildah-containers-storage-pvc.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-buildah-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    limits:
+      storage: 150Gi
+    requests:
+      storage: 150Gi
+  storageClassName: gp3-csi
+

--- a/.tekton/pvcs/buildah-temp-storage-pvc.yaml
+++ b/.tekton/pvcs/buildah-temp-storage-pvc.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-buildah-temp-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    limits:
+      storage: 60Gi
+    requests:
+      storage: 60Gi
+  storageClassName: gp3-csi
+

--- a/.tekton/tasks/buildah-task.yaml
+++ b/.tekton/tasks/buildah-task.yaml
@@ -145,6 +145,13 @@ spec:
         Storage root dir for the spaces required by buildah when building images.
       mountPath: /var/lib/containers/storage
       name: buildah-storage-dir
+
+    - description: |
+        Storage for temp spaces required by buildah cache when building images.
+      mountPath: /var/tmp
+      name: buildah-temp-cache
+
+
     - description: An optional workspace that allows providing a .docker/config.json file for Buildah to access the container registry. The file should be placed at the root of the Workspace with name config.json or .dockerconfigjson.
       name: dockerconfig
       optional: true


### PR DESCRIPTION
1. Fix broken pipeline - Images are not built and not pushed because of cache temp storage required by buildah and is currently utilizing only ephemeral spaces of cluster nodes - thus mount a new volume into the path used by  buildah for temporary cache.
2. Speed up the build process and push process.