### PR TITLE
fix: improve logging

### DIFF
--- a/kustomize/base/nginx/nginx_cache.conf
+++ b/kustomize/base/nginx/nginx_cache.conf
@@ -18,13 +18,13 @@ http {
                              '"$http_referer" "$http_user_agent"'
                              'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
 
-    log_format cache_log '[$time_local] ($upstream_cache_status) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization_present';
+    log_format cache_log '[$time_local] traceId: $http_traceId - ($upstream_cache_status) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization_present';
 
-    log_format no_cache_log '[$time_local] (BYPASSED) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization_present';
+    log_format no_cache_log '[$time_local] traceId: $http_traceId - (BYPASSED) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization_present';
 
-    log_format mirror_log '[$time_local] (MIRROR) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization_present';
+    log_format mirror_log '[$time_local] traceId: $http_traceId -  (MIRROR) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization_present';
 
-    log_format nvai_cache_log '[$time_local] ($upstream_cache_status) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization_present. Final Auth: $http_authorization_present';
+    log_format nvai_cache_log '[$time_local] traceId: $http_traceId - ($upstream_cache_status) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization_present. Final Auth: $http_authorization_present';
 
     include /etc/nginx/conf.d/variables/*.conf;
 

--- a/src/cve/nodes/cve_checklist_node.py
+++ b/src/cve/nodes/cve_checklist_node.py
@@ -20,7 +20,7 @@ import re
 
 from morpheus_llm.llm.nodes.extracter_node import ManualExtracterNode
 
-from ..utils.error_handling_decorator import catch_pipeline_errors_methods_async_args
+from ..utils.error_handling_decorator import catch_pipeline_errors_methods_async_kwargs
 from ..utils.loggers_factory import LoggingFactory, trace_id
 
 from morpheus_llm.llm import LLMLambdaNode
@@ -88,7 +88,7 @@ class CVEChecklistNode(LLMNode):
                       inputs=[("*", "*")],
                       node=PromptTemplateNode(template=cve_prompt1, template_format="jinja"))
 
-        self.add_node("extract_trace_id", node=ManualExtracterNode(input_names=['trace_id']), is_output=True)
+        self.add_node("extract_trace_id", node=ManualExtracterNode(input_names=['trace_id']))
         self.add_node("use_trace_id", inputs=[("/extract_trace_id", "trace_id")],
                       node=LLMLambdaNode(self.__set_trace_id))
         gen_node_1 = LLMGenerateNode(llm_client=llm_client)
@@ -109,7 +109,7 @@ class CVEChecklistNode(LLMNode):
         self.add_node("output_parser", inputs=checklist_prompts, node=LLMLambdaNode(self._parse_list), is_output=True)
         self.trace_id_value = ""
 
-    @catch_pipeline_errors_methods_async_args
+    @catch_pipeline_errors_methods_async_kwargs
     async def _parse_list(self, text: list[str]) -> list[list[str]]:
         """
         Asynchronously parse a list of strings, each representing a list, into a list of lists.
@@ -137,11 +137,8 @@ class CVEChecklistNode(LLMNode):
         """
         return_val = []
         trace_id.set(self.trace_id_value)
-        list2 = []
-        print(list2[1])
         for checklist_num, x in enumerate(text):
             try:
-                logger.debug("ZviDebug06052024 test")
                 # Remove any text not enclosed by square brackets
                 x = x[x.find('['):x.rfind(']') + 1]
 

--- a/src/cve/nodes/cve_checklist_node.py
+++ b/src/cve/nodes/cve_checklist_node.py
@@ -17,13 +17,17 @@
 import ast
 import logging
 import re
-from ..utils.loggers_factory import LoggingFactory
+
+from morpheus_llm.llm.nodes.extracter_node import ManualExtracterNode
+
+from ..utils.error_handling_decorator import catch_pipeline_errors_methods_async_args
+from ..utils.loggers_factory import LoggingFactory, trace_id
 
 from morpheus_llm.llm import LLMLambdaNode
 from morpheus_llm.llm import LLMNode
 from morpheus_llm.llm.nodes.llm_generate_node import LLMGenerateNode
 from morpheus_llm.llm.nodes.prompt_template_node import PromptTemplateNode
-from morpheus_llm.llm.services.llm_service import LLMClient
+from morpheus_llm.llm.services.llm_service import LLMClient, LLMService
 
 from ..data_models.config import LLMModelConfig
 from ..utils.prompting import MOD_FEW_SHOT
@@ -42,68 +46,6 @@ def return_escaped_content_backslashes(match) -> str:
     return match.group(0).replace("\\", "\\\\")
 
 
-async def _parse_list(text: list[str]) -> list[list[str]]:
-    """
-    Asynchronously parse a list of strings, each representing a list, into a list of lists.
-
-    Parameters
-    ----------
-    text : list of str
-        A list of strings, each intended to be parsed into a list.
-
-    Returns
-    -------
-    list of lists of str
-        A list of lists, parsed from the input strings.
-
-    Raises
-    ------
-    ValueError
-        If the string cannot be parsed into a list or if the parsed object is not a list.
-
-    Notes
-    -----
-    This function tries to fix strings that represent lists with unescaped quotes by calling
-    `attempt_fix_list_string` and then uses `ast.literal_eval` for safe parsing of the string into a list.
-    It ensures that each element of the parsed list is actually a list and will raise an error if not.
-    """
-    return_val = []
-
-    for checklist_num, x in enumerate(text):
-        try:
-            # Remove any text not enclosed by square brackets
-            x = x[x.find('['):x.rfind(']') + 1]
-
-            # Remove newline characters that can cause incorrect string escaping in the next step
-            x = x.replace("\n", "")
-
-            # Ensure backslashes are escaped only when they are not already escaping other characters
-            x = re.sub(r'\\[^"\'\\nrtbf]', return_escaped_content_backslashes, x)
-
-            # Try to do some very basic string cleanup to fix unescaped quotes
-            x = attempt_fix_list_string(x)
-
-            # Only proceed if the input is a valid Python literal
-            # This isn't really dangerous, literal_eval only evaluates a small subset of python
-            current = ast.literal_eval(x)
-
-            # Ensure that the parsed data is a list
-            if not isinstance(current, list):
-                raise ValueError(f"Input is not a list: {x}")
-
-            # Process the list items
-            for i in range(len(current)):
-                if (isinstance(current[i], list) and len(current[i]) == 1):
-                    current[i] = current[i][0]
-
-            return_val.append(current)
-        except (ValueError, SyntaxError) as e:
-            # Handle the error, log it, or re-raise it with additional context
-            raise ValueError(f"Failed to parse input for checklist number {checklist_num}: {x}. Error: {e}")
-
-    return return_val
-
-
 class CVEChecklistNode(LLMNode):
     """
     A node that orchestrates the process of generating a checklist for CVE (Common Vulnerabilities and Exposures) items.
@@ -111,7 +53,7 @@ class CVEChecklistNode(LLMNode):
     """
 
     def __init__(self, *, prompt: str,
-                 llm_client: LLMClient, 
+                 llm_client: LLMClient,
                  enable_llm_list_parsing: bool = False):
         """
         Initialize the CVEChecklistNode with optional caching and a vulnerability endpoint retriever.
@@ -126,27 +68,29 @@ class CVEChecklistNode(LLMNode):
             An instance of a vulnerability endpoint retriever. If None, defaults to `NISTCVERetriever`.
         """
         super().__init__()
-
         if not prompt:
             prompt = DEFAULT_CHECKLIST_PROMPT
 
         intel = (
-            additional_intel_prompting +
-            "\n\nIf a vulnerable function or method is mentioned in the CVE description, ensure the first checklist item verifies whether this function or method is being called from the code or used by the code. if exists, do it together with containing package name."
-            "\nThe vulnerable version of the vulnerable package is already verified to be installed within the container. Check only the other factors that affect exploitability, no need to verify version again."
+                additional_intel_prompting +
+                "\n\nIf a vulnerable function or method is mentioned in the CVE description, ensure the first checklist item verifies whether this function or method is being called from the code or used by the code. if exists, do it together with containing package name."
+                "\nThe vulnerable version of the vulnerable package is already verified to be installed within the container. Check only the other factors that affect exploitability, no need to verify version again."
         )
 
         cve_prompt1 = (
-            prompt
-            + intel
+                prompt
+                + intel
         )
-
         # Add a node to create a prompt for CVE checklist generation based on the CVE details obtained from the lookup
         # node
+
         self.add_node("checklist_prompt",
                       inputs=[("*", "*")],
                       node=PromptTemplateNode(template=cve_prompt1, template_format="jinja"))
 
+        self.add_node("extract_trace_id", node=ManualExtracterNode(input_names=['trace_id']), is_output=True)
+        self.add_node("use_trace_id", inputs=[("/extract_trace_id", "trace_id")],
+                      node=LLMLambdaNode(self.__set_trace_id))
         gen_node_1 = LLMGenerateNode(llm_client=llm_client)
         self.add_node("chat1", inputs=["/checklist_prompt"], node=gen_node_1)
 
@@ -162,4 +106,73 @@ class CVEChecklistNode(LLMNode):
 
         checklist_prompts = ["/chat2"] if enable_llm_list_parsing else ["/chat1"]
         # Add an output parser node to process the final generated checklist into a structured list
-        self.add_node("output_parser", inputs=checklist_prompts, node=LLMLambdaNode(_parse_list), is_output=True)
+        self.add_node("output_parser", inputs=checklist_prompts, node=LLMLambdaNode(self._parse_list), is_output=True)
+        self.trace_id_value = ""
+
+    @catch_pipeline_errors_methods_async_args
+    async def _parse_list(self, text: list[str]) -> list[list[str]]:
+        """
+        Asynchronously parse a list of strings, each representing a list, into a list of lists.
+
+        Parameters
+        ----------
+        text : list of str
+            A list of strings, each intended to be parsed into a list.
+
+        Returns
+        -------
+        list of lists of str
+            A list of lists, parsed from the input strings.
+
+        Raises
+        ------
+        ValueError
+            If the string cannot be parsed into a list or if the parsed object is not a list.
+
+        Notes
+        -----
+        This function tries to fix strings that represent lists with unescaped quotes by calling
+        `attempt_fix_list_string` and then uses `ast.literal_eval` for safe parsing of the string into a list.
+        It ensures that each element of the parsed list is actually a list and will raise an error if not.
+        """
+        return_val = []
+        trace_id.set(self.trace_id_value)
+        list2 = []
+        print(list2[1])
+        for checklist_num, x in enumerate(text):
+            try:
+                logger.debug("ZviDebug06052024 test")
+                # Remove any text not enclosed by square brackets
+                x = x[x.find('['):x.rfind(']') + 1]
+
+                # Remove newline characters that can cause incorrect string escaping in the next step
+                x = x.replace("\n", "")
+
+                # Ensure backslashes are escaped only when they are not already escaping other characters
+                x = re.sub(r'\\[^"\'\\nrtbf]', return_escaped_content_backslashes, x)
+
+                # Try to do some very basic string cleanup to fix unescaped quotes
+                x = attempt_fix_list_string(x)
+
+                # Only proceed if the input is a valid Python literal
+                # This isn't really dangerous, literal_eval only evaluates a small subset of python
+                current = ast.literal_eval(x)
+
+                # Ensure that the parsed data is a list
+                if not isinstance(current, list):
+                    raise ValueError(f"Input is not a list: {x}")
+
+                # Process the list items
+                for i in range(len(current)):
+                    if (isinstance(current[i], list) and len(current[i]) == 1):
+                        current[i] = current[i][0]
+
+                return_val.append(current)
+            except (ValueError, SyntaxError) as e:
+                # Handle the error, log it, or re-raise it with additional context
+                raise ValueError(f"Failed to parse input for checklist number {checklist_num}: {x}. Error: {e}")
+
+        return return_val
+
+    async def __set_trace_id(self, trace_id: list[str]):
+        self.trace_id_value = trace_id[0]

--- a/src/cve/nodes/cve_justification_node.py
+++ b/src/cve/nodes/cve_justification_node.py
@@ -176,4 +176,4 @@ class CVEJustifyNode(LLMNode):
     async def __set_trace_id(self, trace_id: list[str]):
         self.trace_id_value = trace_id[0]
         trace_id_var.set(self.trace_id_value)
-        logger.debug("ZviDebug1--> Justification node")
+        # logger.debug("ZviDebug1--> Justification node")

--- a/src/cve/nodes/cve_justification_node.py
+++ b/src/cve/nodes/cve_justification_node.py
@@ -15,6 +15,9 @@
 
 
 import logging
+
+from ..utils.error_handling_decorator import catch_pipeline_errors_methods_async_kwargs, \
+    catch_pipeline_errors_methods_async_args
 from ..utils.loggers_factory import LoggingFactory
 from textwrap import dedent
 
@@ -109,6 +112,7 @@ class CVEJustifyNode(LLMNode):
         """
         super().__init__()
 
+        @catch_pipeline_errors_methods_async_args
         async def _strip_summaries(summaries: list[str]) -> list[str]:
             return [summary.strip() for summary in summaries]
 
@@ -122,6 +126,7 @@ class CVEJustifyNode(LLMNode):
 
         self.add_node("justify", inputs=["/justification_prompt"], node=LLMGenerateNode(llm_client=llm_client))
 
+        @catch_pipeline_errors_methods_async_args
         async def _parse_justification(justifications: list[str]) -> dict[str, list[str]]:
             labels: list[str] = []
             reasons: list[str] = []

--- a/src/cve/nodes/cve_justification_node.py
+++ b/src/cve/nodes/cve_justification_node.py
@@ -16,9 +16,11 @@
 
 import logging
 
+from morpheus_llm.llm.nodes.extracter_node import ManualExtracterNode
+
 from ..utils.error_handling_decorator import catch_pipeline_errors_methods_async_kwargs, \
-    catch_pipeline_errors_methods_async_args
-from ..utils.loggers_factory import LoggingFactory
+    catch_pipeline_errors_methods_async_kwargs
+from ..utils.loggers_factory import LoggingFactory, trace_id as trace_id_var
 from textwrap import dedent
 
 from morpheus_llm.llm import LLMLambdaNode
@@ -111,12 +113,12 @@ class CVEJustifyNode(LLMNode):
             The LLM client to use for generating the justification.
         """
         super().__init__()
+        self.trace_id_value = ""
 
-        @catch_pipeline_errors_methods_async_args
-        async def _strip_summaries(summaries: list[str]) -> list[str]:
-            return [summary.strip() for summary in summaries]
-
-        self.add_node('stripped_summaries', inputs=['summaries'], node=LLMLambdaNode(_strip_summaries))
+        self.add_node("extract_trace_id", node=ManualExtracterNode(input_names=['trace_id']))
+        self.add_node("use_trace_id", inputs=[("/extract_trace_id", "trace_id")],
+                      node=LLMLambdaNode(self.__set_trace_id))
+        self.add_node('stripped_summaries', inputs=['summaries'], node=LLMLambdaNode(self._strip_summaries))
 
         justification_prompt = prompt or self.DEFAULT_JUSTIFICATION_PROMPT
 
@@ -126,39 +128,52 @@ class CVEJustifyNode(LLMNode):
 
         self.add_node("justify", inputs=["/justification_prompt"], node=LLMGenerateNode(llm_client=llm_client))
 
-        @catch_pipeline_errors_methods_async_args
-        async def _parse_justification(justifications: list[str]) -> dict[str, list[str]]:
-            labels: list[str] = []
-            reasons: list[str] = []
-            affected_status: list[str] = []
-
-            split_justifications = [j.split('\n') for j in justifications]
-
-            for j in split_justifications:
-
-                if len(j) < 2:
-                    raise ValueError(
-                        f"Invalid justification format: {j}. Must be the label and the reason separated by a newline")
-
-                justification_label_raw = j[0].strip()
-                justification_label = self.RAW_TO_FINAL_JUSTIFICATION_MAP.get(justification_label_raw,
-                                                                              justification_label_raw)
-                labels.append(justification_label)
-                reasons.append('\n'.join(j[1:]).strip())
-                try:
-                    affected_status.append(self.JUSTIFICATION_TO_AFFECTED_STATUS_MAP[justification_label])
-                except KeyError:
-                    logger.error("Invalid justification label: '%s', setting affected_status='UNKNOWN'",
-                                 justification_label)
-                    affected_status.append("UNKNOWN")
-
-            return {
-                self.JUSTIFICATION_LABEL_COL_NAME: labels,
-                self.JUSTIFICATION_REASON_COL_NAME: reasons,
-                self.AFFECTED_STATUS_COL_NAME: affected_status
-            }
-
         self.add_node("parse_justification",
                       inputs=['/justify'],
-                      node=LLMLambdaNode(_parse_justification),
+                      node=LLMLambdaNode(self._parse_justification),
                       is_output=True)
+
+    @catch_pipeline_errors_methods_async_kwargs
+    async def _parse_justification(self, justifications: list[str]) -> dict[str, list[str]]:
+        logger.debug(f"before, trace_id assignment")
+        trace_id_var.set(self.trace_id_value)
+        logger.debug(f"after, trace_id assignment, trace_id={self.trace_id_value}")
+        labels: list[str] = []
+        reasons: list[str] = []
+        affected_status: list[str] = []
+
+        split_justifications = [j.split('\n') for j in justifications]
+
+        for j in split_justifications:
+
+            if len(j) < 2:
+                raise ValueError(
+                    f"Invalid justification format: {j}. Must be the label and the reason separated by a newline")
+
+            justification_label_raw = j[0].strip()
+            justification_label = self.RAW_TO_FINAL_JUSTIFICATION_MAP.get(justification_label_raw,
+                                                                          justification_label_raw)
+            labels.append(justification_label)
+            reasons.append('\n'.join(j[1:]).strip())
+            try:
+                affected_status.append(self.JUSTIFICATION_TO_AFFECTED_STATUS_MAP[justification_label])
+            except KeyError:
+                logger.error("Invalid justification label: '%s', setting affected_status='UNKNOWN'",
+                             justification_label)
+                affected_status.append("UNKNOWN")
+
+        return {
+            self.JUSTIFICATION_LABEL_COL_NAME: labels,
+            self.JUSTIFICATION_REASON_COL_NAME: reasons,
+            self.AFFECTED_STATUS_COL_NAME: affected_status
+        }
+
+    @catch_pipeline_errors_methods_async_kwargs
+    async def _strip_summaries(self, summaries: list[str]) -> list[str]:
+        trace_id_var.set(self.trace_id_value)
+        return [summary.strip() for summary in summaries]
+
+    async def __set_trace_id(self, trace_id: list[str]):
+        self.trace_id_value = trace_id[0]
+        trace_id_var.set(self.trace_id_value)
+        logger.debug("ZviDebug1--> Justification node")

--- a/src/cve/nodes/cve_summary_node.py
+++ b/src/cve/nodes/cve_summary_node.py
@@ -100,7 +100,6 @@ class CVESummaryNode(LLMNode):
     async def concat_checklist_responses(self, agent_q_and_a: list[list[dict]]) -> list[str]:
         trace_id_var.set(self.trace_id_value)
         concatted_responses = []
-
         for checklist in agent_q_and_a:
             checklist_str = '\n'.join([get_checklist_item_string(i + 1, item) for i, item in enumerate(checklist)])
             concatted_responses.append(checklist_str)
@@ -124,4 +123,4 @@ class CVESummaryNode(LLMNode):
     async def __set_trace_id(self, trace_id: list[str]):
         self.trace_id_value = trace_id[0]
         trace_id_var.set(self.trace_id_value)
-        logger.debug("ZviDebug1--> Summary node")
+        # logger.debug("ZviDebug1--> Summary node")

--- a/src/cve/nodes/cve_summary_node.py
+++ b/src/cve/nodes/cve_summary_node.py
@@ -15,6 +15,9 @@
 
 
 import logging
+
+from ..utils.error_handling_decorator import catch_pipeline_errors_methods_async_kwargs, \
+    catch_pipeline_errors_methods_async_args
 from ..utils.loggers_factory import LoggingFactory
 
 from morpheus_llm.llm import LLMLambdaNode
@@ -70,6 +73,7 @@ class CVESummaryNode(LLMNode):
                       is_output=True)
 
         # Concatenate the output of the checklist responses into a single string
+        @catch_pipeline_errors_methods_async_args
         async def concat_checklist_responses(agent_q_and_a: list[list[dict]]) -> list[str]:
             concatted_responses = []
 

--- a/src/cve/nodes/cve_summary_node.py
+++ b/src/cve/nodes/cve_summary_node.py
@@ -16,9 +16,11 @@
 
 import logging
 
+from morpheus_llm.llm.nodes.extracter_node import ManualExtracterNode
+
 from ..utils.error_handling_decorator import catch_pipeline_errors_methods_async_kwargs, \
-    catch_pipeline_errors_methods_async_args
-from ..utils.loggers_factory import LoggingFactory
+    catch_pipeline_errors_methods_async_kwargs
+from ..utils.loggers_factory import LoggingFactory, trace_id as trace_id_var
 
 from morpheus_llm.llm import LLMLambdaNode
 from morpheus_llm.llm import LLMNode
@@ -53,37 +55,19 @@ class CVESummaryNode(LLMNode):
             The LLM client to use for generating the summary.
         """
         super().__init__()
+        self.trace_id_value = ""
 
-        async def build_summary_output(checklist_inputs: list[list[str]],
-                                       checklist_outputs: list[list[str]],
-                                       intermediate_steps: list[list[list]]) -> list[list[dict]]:
-            summary_output = []
-
-            for check_in, check_out, steps in zip(checklist_inputs, checklist_outputs, intermediate_steps):
-                summary_output.append([{
-                    "question": q, "response": r, "intermediate_steps": s
-                } for q, r, s in zip(check_in, check_out, steps)])  # yapf: disable
-
-            return summary_output
+        self.add_node("extract_trace_id", node=ManualExtracterNode(input_names=['trace_id']))
+        self.add_node("use_trace_id", inputs=[("/extract_trace_id", "trace_id")],
+                      node=LLMLambdaNode(self.__set_trace_id))
 
         # Build the output for the checklist as a list of dictionaries
         self.add_node("checklist",
                       inputs=["checklist_inputs", "checklist_outputs", "intermediate_steps"],
-                      node=LLMLambdaNode(build_summary_output),
+                      node=LLMLambdaNode(self.build_summary_output),
                       is_output=True)
 
-        # Concatenate the output of the checklist responses into a single string
-        @catch_pipeline_errors_methods_async_args
-        async def concat_checklist_responses(agent_q_and_a: list[list[dict]]) -> list[str]:
-            concatted_responses = []
-
-            for checklist in agent_q_and_a:
-                checklist_str = '\n'.join([get_checklist_item_string(i + 1, item) for i, item in enumerate(checklist)])
-                concatted_responses.append(checklist_str)
-
-            return concatted_responses
-
-        self.add_node('results', inputs=['/checklist'], node=LLMLambdaNode(concat_checklist_responses))
+        self.add_node('results', inputs=['/checklist'], node=LLMLambdaNode(self.concat_checklist_responses))
 
         summary_prompt = prompt or DEFAULT_SUMMARY_PROMPT
 
@@ -96,3 +80,48 @@ class CVESummaryNode(LLMNode):
                       inputs=["/summary_prompt"],
                       node=LLMGenerateNode(llm_client=llm_client),
                       is_output=True)
+
+    # Concatenate the output of the checklist responses into a single string
+    @catch_pipeline_errors_methods_async_kwargs
+    async def concat_checklist_responses(self, agent_q_and_a: list[list[dict]]) -> list[str]:
+        logger.debug(f"before, trace_id assignment")
+        trace_id_var.set(self.trace_id_value)
+        logger.debug(f"after, trace_id assignment, trace_id={self.trace_id_value}")
+        concatted_responses = []
+
+        for checklist in agent_q_and_a:
+            checklist_str = '\n'.join([get_checklist_item_string(i + 1, item) for i, item in enumerate(checklist)])
+            concatted_responses.append(checklist_str)
+
+        return concatted_responses
+
+    # Concatenate the output of the checklist responses into a single string
+    @catch_pipeline_errors_methods_async_kwargs
+    async def concat_checklist_responses(self, agent_q_and_a: list[list[dict]]) -> list[str]:
+        trace_id_var.set(self.trace_id_value)
+        concatted_responses = []
+
+        for checklist in agent_q_and_a:
+            checklist_str = '\n'.join([get_checklist_item_string(i + 1, item) for i, item in enumerate(checklist)])
+            concatted_responses.append(checklist_str)
+
+        return concatted_responses
+
+    @catch_pipeline_errors_methods_async_kwargs
+    async def build_summary_output(self, checklist_inputs: list[list[str]],
+                                   checklist_outputs: list[list[str]],
+                                   intermediate_steps: list[list[list]]) -> list[list[dict]]:
+
+        trace_id_var.set(self.trace_id_value)
+        summary_output = []
+        for check_in, check_out, steps in zip(checklist_inputs, checklist_outputs, intermediate_steps):
+            summary_output.append([{
+                "question": q, "response": r, "intermediate_steps": s
+            } for q, r, s in zip(check_in, check_out, steps)])  # yapf: disable
+
+        return summary_output
+
+    async def __set_trace_id(self, trace_id: list[str]):
+        self.trace_id_value = trace_id[0]
+        trace_id_var.set(self.trace_id_value)
+        logger.debug("ZviDebug1--> Summary node")

--- a/src/cve/pipeline/engine.py
+++ b/src/cve/pipeline/engine.py
@@ -15,6 +15,8 @@
 
 
 import logging
+
+from ..utils.error_handling_decorator import catch_pipeline_errors
 from ..utils.loggers_factory import LoggingFactory, trace_id
 import os.path
 import pickle
@@ -58,6 +60,7 @@ OUTPUT_CONTAIN_BOTH_ACTION_AND_FINAL_ANSWER = "Parsing LLM output produced both 
 
 logger = LoggingFactory.get_agent_logger(__name__)
 
+
 def retrieve_from_cache(base_pickle_dir, repo_url, repo_ref) -> tuple:
     if not os.path.exists(base_pickle_dir):
         os.makedirs(base_pickle_dir)
@@ -74,6 +77,7 @@ def retrieve_from_cache(base_pickle_dir, repo_url, repo_ref) -> tuple:
 
     return [], False
 
+
 def save_to_cache(base_pickle_dir: str, repo_url: str, repo_ref: str, documents: list[Document]):
     cached_documents_path = \
         (f"{base_pickle_dir}/"
@@ -83,12 +87,13 @@ def save_to_cache(base_pickle_dir: str, repo_url: str, repo_ref: str, documents:
     with open(cached_documents_path, 'wb') as doc_file:  # open a text file
         pickle.dump(documents, doc_file)
 
+
 def _create_wrapper_llm(run_config: RunConfig) -> LangchainLLMClientWrapper | ChatOpenAI:
     if run_config.engine.agent.model.service.type.lower() == 'openai':
         return ChatOpenAI(client=ChatCompletion(), model_name=run_config.engine.agent.model.model_name,
-                                 max_tokens=run_config.engine.agent.model.max_tokens,
-                                 temperature=run_config.engine.agent.model.temperature,
-                                 top_p=run_config.engine.agent.model.top_p)
+                          max_tokens=run_config.engine.agent.model.max_tokens,
+                          temperature=run_config.engine.agent.model.temperature,
+                          top_p=run_config.engine.agent.model.top_p)
     else:
         chat_service = LLMService.create(run_config.engine.agent.model.service.type,
                                          **run_config.engine.agent.model.service.model_dump(exclude={"type"},
@@ -96,7 +101,8 @@ def _create_wrapper_llm(run_config: RunConfig) -> LangchainLLMClientWrapper | Ch
         chat_client = chat_service.get_client(**run_config.engine.agent.model.model_dump(exclude={"service", "type"},
                                                                                          by_alias=True))
         return LangchainLLMClientWrapper(client=chat_client)
-   
+
+
 def _run_retrieval_qa_tool(run_config: RunConfig, retrieval_qa_tool: RetrievalQA, query: str) -> str | dict:
     """
     Runs a given retrieval QA tool on the provided query. Returns a dict of the result string and source
@@ -112,7 +118,8 @@ def _run_retrieval_qa_tool(run_config: RunConfig, retrieval_qa_tool: RetrievalQA
     # If not returning source documents, return only the result as a string
     else:
         return output_dict["result"]
-                 
+
+
 def _create_notify_handler(run_config: RunConfig):
     def notify_llm_to_rephrase(exception: OutputParserException) -> str:
         if run_config.engine.agent.model.service.type.lower() == 'openai':
@@ -123,10 +130,14 @@ def _create_notify_handler(run_config: RunConfig):
                         f"and a final answer at the same time")
 
         return "Check your output and make sure it conforms, use the Action/Action Input syntax"
-    return notify_llm_to_rephrase
-    
-def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientWrapper | ChatOpenAI, embeddings: Embeddings):
 
+    return notify_llm_to_rephrase
+
+
+def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientWrapper | ChatOpenAI,
+                         embeddings: Embeddings):
+
+    @catch_pipeline_errors
     def inner_create_agent_fn(context: LLMContext, analysis_data: list[list[dict]]):
 
         def get_analysis_data(query: str) -> list[list[dict]]:
@@ -134,11 +145,11 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
             Fetches the container image analysis data.
             """
             return analysis_data
-                    
+
         tools: list[Tool] = []
-        
+
         vdb_map: AgentMorpheusInfo.VdbPaths = context.message().get_metadata("info.vdb")  # type: ignore
-        
+
         if (vdb_map.code_vdb_path is not None):
             # load code vector DB
             code_vector_db = FAISS.load_local(vdb_map.code_vdb_path, embeddings, allow_dangerous_deserialization=True)
@@ -211,7 +222,7 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
                 ),
             ),
         )
-        
+
         # Define a system prompt that sets the context for the language model's task.
         DEFAULT_SYS_PROMPT = f"""
             You are a very powerful and highly knowledgeable cybersecurity assistant specializing in Common Vulnerabilities and Exposures (CVE) analysis.
@@ -252,13 +263,13 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
         ).replace(
             "Question: the input question you must answer",
             "Metric: the input metric you are evaluating in the following format: metric_name (metric_abbreviation)\n"
-            "Question: the input question you must answer"       
+            "Question: the input question you must answer"
         ).replace(
             "Final Answer: the final answer to the original input question",
             "Final Answer: the final answer to the original input question. The final answer must follow this format: <metric_abbreviation>:<value_abbreviation>\n\n"
             "IMPORTANT: After every Thought, you must provide an Action and Action Input, unless you are ready to provide the Final Answer. Do not stop after a Thought. This rule must always be followed."
         )
-        
+
         if run_config.engine.agent.model.service.type.lower() == 'openai':
             prompt_template = prompt_template.replace("Final Answer: the final answer to the original input question",
                                                       "Final Answer: the final answer to the original input question. \n"
@@ -272,11 +283,13 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
 
     return inner_create_agent_fn
 
-def _build_dynamic_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientWrapper | ChatOpenAI, embeddings: Embeddings):
 
+def _build_dynamic_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientWrapper | ChatOpenAI,
+                            embeddings: Embeddings):
     # Initialize a SerpAPIWrapper object to perform internet searches.
     search = MorpheusSerpAPIWrapper(max_retries=run_config.general.max_retries)
 
+    @catch_pipeline_errors
     def inner_create_agent_fn(context: LLMContext):
         trace_id.set(context.message().get_metadata("input").scan.id)
         tools: list[Tool] = [
@@ -414,7 +427,7 @@ def _build_dynamic_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClie
         sys_prompt = run_config.engine.agent.model.prompt or DEFAULT_SYS_PROMPT
 
         handler = _create_notify_handler(run_config)
-        
+
         # Initialize an agent with the tools and settings defined above.
         # This agent is designed to handle zero-shot reaction descriptions and parse errors.
         agent = initialize_agent(
@@ -480,6 +493,7 @@ def _build_dynamic_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClie
 
     return inner_create_agent_fn
 
+
 def build_engine(*, run_config: RunConfig, embeddings: Embeddings):
     summary_service = LLMService.create(run_config.engine.summary_model.service.type,
                                         **run_config.engine.summary_model.service.model_dump(exclude={"type"}))
@@ -491,7 +505,7 @@ def build_engine(*, run_config: RunConfig, embeddings: Embeddings):
                                           **run_config.engine.checklist_model.service.model_dump(exclude={"type"},
                                                                                                  by_alias=True))
     wrapper_llm = _create_wrapper_llm(run_config)
-    
+
     engine = LLMEngine()
 
     checklist_node = CVEChecklistNode(prompt=run_config.engine.checklist_model.prompt,
@@ -503,7 +517,7 @@ def build_engine(*, run_config: RunConfig, embeddings: Embeddings):
     engine.add_node("extract_prompt", node=ManualExtracterNode(input_names=checklist_node.get_input_names()))
 
     engine.add_node("checklist", inputs=[("/extract_prompt/*", "*")], node=checklist_node)
-    
+
     engine.add_node("agent",
                     inputs=[("/checklist", "input")],
                     node=CVELangChainAgentNode(
@@ -553,7 +567,7 @@ def build_engine(*, run_config: RunConfig, embeddings: Embeddings):
         CVEJustifyNode.JUSTIFICATION_REASON_COL_NAME,
         CVEJustifyNode.AFFECTED_STATUS_COL_NAME
     ]
-    
+
     if run_config.general.generate_cvss_score:
         handler_inputs.extend([
             f"/cvss/{CVECVSSNode.CVSS_VECTOR_STRING_COL_NAME}",

--- a/src/cve/pipeline/engine.py
+++ b/src/cve/pipeline/engine.py
@@ -516,7 +516,7 @@ def build_engine(*, run_config: RunConfig, embeddings: Embeddings):
 
     engine.add_node("extract_prompt", node=ManualExtracterNode(input_names=checklist_node.get_input_names()))
 
-    engine.add_node("checklist", inputs=[("/extract_prompt/*", "*")], node=checklist_node)
+    engine.add_node("checklist", inputs=[("/extract_prompt/*", "*"), ("trace_id", "trace_id")], node=checklist_node)
 
     engine.add_node("agent",
                     inputs=[("/checklist", "input")],

--- a/src/cve/pipeline/engine.py
+++ b/src/cve/pipeline/engine.py
@@ -534,7 +534,7 @@ def build_engine(*, run_config: RunConfig, embeddings: Embeddings):
 
     engine.add_node('summary',
                     inputs=[("/checklist", "checklist_inputs"), ("/agent/outputs", "checklist_outputs"),
-                            "/agent/intermediate_steps"],
+                            "/agent/intermediate_steps", ("trace_id", "trace_id")],
                     node=CVESummaryNode(prompt=run_config.engine.summary_model.prompt,
                                         llm_client=summary_service.get_client(
                                             **run_config.engine.summary_model.model_dump(
@@ -544,7 +544,7 @@ def build_engine(*, run_config: RunConfig, embeddings: Embeddings):
                     )
 
     engine.add_node('justification',
-                    inputs=[("/summary/summary", "summaries")],
+                    inputs=[("/summary/summary", "summaries"),("trace_id", "trace_id")],
                     node=CVEJustifyNode(prompt=run_config.engine.justification_model.prompt,
                                         llm_client=justification_service.get_client(
                                             **run_config.engine.justification_model.model_dump(

--- a/src/cve/pipeline/input.py
+++ b/src/cve/pipeline/input.py
@@ -16,6 +16,8 @@
 
 import asyncio
 import logging
+
+from ..utils.error_handling_decorator import catch_pipeline_errors
 from ..utils.loggers_factory import LoggingFactory, trace_id
 import os
 import typing
@@ -99,6 +101,7 @@ def build_http_input(pipe: LinearPipeline, config: Config, input: HttpInputConfi
     return http_server_logger
 
 
+@catch_pipeline_errors
 def build_input(pipe: LinearPipeline, config: Config, run_config: RunConfig):
     # Create the base directories for the VDB and source code if they don't already exist
     for file_dir in (run_config.general.base_vdb_dir, run_config.general.base_git_dir):
@@ -168,13 +171,13 @@ def build_input(pipe: LinearPipeline, config: Config, run_config: RunConfig):
 
     pipe.add_stage(build_vdb_stage)
 
+    @catch_pipeline_errors
     @stage
     def fetch_intel(message: AgentMorpheusEngineInput) -> AgentMorpheusEngineInput:
         trace_id.set(message.input.scan.id)
+
         async def _inner():
-
             async with aiohttp.ClientSession() as session:
-
                 intel_retriever = IntelRetriever(session=session,
                                                  plugins_config=run_config.general.intel_plugins,
                                                  retry_on_client_errors=run_config.general.retry_on_client_errors)
@@ -192,6 +195,7 @@ def build_input(pipe: LinearPipeline, config: Config, run_config: RunConfig):
 
     pipe.add_stage(fetch_intel(config))
 
+    @catch_pipeline_errors
     @stage
     def process_sbom(message: AgentMorpheusEngineInput) -> AgentMorpheusEngineInput:
         trace_id.set(message.input.scan.id)
@@ -228,12 +232,14 @@ def build_input(pipe: LinearPipeline, config: Config, run_config: RunConfig):
 
     pipe.add_stage(process_sbom(config))
 
+    @catch_pipeline_errors
     @stage
     def check_vulnerable_dependencies(message: AgentMorpheusEngineInput) -> AgentMorpheusEngineInput:
         """Check for vulnerable packages in the dependency graph and update the message object."""
         if not run_config.general.use_dependency_checker:
             message.info.vulnerable_dependencies = [VulnerableDependencies(
-                vuln_id=cve_intel.cve_id, vuln_package_intel_sources=[], vulnerable_sbom_packages=[]) for cve_intel in message.info.intel]
+                vuln_id=cve_intel.cve_id, vuln_package_intel_sources=[], vulnerable_sbom_packages=[]) for cve_intel in
+                message.info.intel]
             return message
         trace_id.set(message.input.scan.id)
         sbom = message.info.sbom.packages
@@ -312,7 +318,6 @@ def build_input(pipe: LinearPipeline, config: Config, run_config: RunConfig):
     if run_config.input.type != 'http':
         @stage
         def debug_input(message: AgentMorpheusEngineInput) -> AgentMorpheusEngineInput:
-
             # Save the input object to disk for debugging
             with open("./.tmp/input_object.json", "w") as f:
                 f.write(message.model_dump_json(indent=2))

--- a/src/cve/pipeline/output.py
+++ b/src/cve/pipeline/output.py
@@ -16,6 +16,8 @@
 
 import json
 import logging
+
+from ..utils.error_handling_decorator import catch_pipeline_errors
 from ..utils.loggers_factory import LoggingFactory, trace_id
 import os
 
@@ -34,8 +36,8 @@ from ..utils.output_formatter import generate_vulnerability_reports
 logger = LoggingFactory.get_agent_logger(__name__)
 
 
+@catch_pipeline_errors
 def build_output(pipe: LinearPipeline, config: Config, run_config: RunConfig):
-
     if (run_config.output.type == "print"):
 
         @stage

--- a/src/cve/pipeline/pipeline.py
+++ b/src/cve/pipeline/pipeline.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import datetime
 import logging
 import os
@@ -41,6 +39,7 @@ from ..stages.convert_to_output_object import convert_to_output_object
 from .engine import build_engine
 from .input import build_input
 from .output import build_output
+from ..utils.error_handling_decorator import catch_pipeline_errors
 from ..utils.loggers_factory import LoggingFactory, trace_id
 
 logger = LoggingFactory.get_agent_logger(__name__)
@@ -86,6 +85,7 @@ def build_pipeline_without_sink(run_config: RunConfig) -> tuple[Config, LinearPi
 
     engine = build_engine(run_config=run_config, embeddings=embeddings)
 
+    @catch_pipeline_errors
     @stage
     def convert_input_to_df(message: AgentMorpheusEngineInput) -> ControlMessage:
         trace_id.set(message.input.scan.id)
@@ -187,6 +187,7 @@ def build_pipeline_without_sink(run_config: RunConfig) -> tuple[Config, LinearPi
 
     pipe.add_stage(LLMEngineStage(config, engine=engine))
 
+    @catch_pipeline_errors
     @stage
     def add_end_timestamp(message: ControlMessage) -> ControlMessage:
         trace_id.set(message.get_metadata("input").scan.id)

--- a/src/cve/pipeline/pipeline.py
+++ b/src/cve/pipeline/pipeline.py
@@ -91,7 +91,7 @@ def build_pipeline_without_sink(run_config: RunConfig) -> tuple[Config, LinearPi
         trace_id.set(message.input.scan.id)
         assert message.info.intel is not None, "The input message must have intel information"
 
-        input_names = ['vuln_id', 'ghsa_id', 'cve_id', 'plugins_intel_data']
+        input_names = ['trace_id', 'vuln_id', 'ghsa_id', 'cve_id', 'plugins_intel_data']
 
         # Determine the input columns that need to be set from the engine (based on checklist_prompt fields)
         input_names.extend([name for name in engine.get_input_names() if name not in input_names])
@@ -103,6 +103,7 @@ def build_pipeline_without_sink(run_config: RunConfig) -> tuple[Config, LinearPi
             "ghsa_id": x.get_ghsa_id(),
             "cve_id": x.get_cve_id(),
             "plugins_intel_data": x.plugins_intel_data,
+            "trace_id": message.input.scan.id,
             **x.model_dump(mode="json")
         } for x in message.info.intel],
                                     sep="_")
@@ -156,6 +157,7 @@ def build_pipeline_without_sink(run_config: RunConfig) -> tuple[Config, LinearPi
         cm.payload(mm)
 
         cm.set_metadata("input", message.input)
+        cm.set_metadata("traceId", message.input.scan.id)
         cm.set_metadata("info.vdb", message.info.vdb)
         cm.set_metadata("info.intel", message.info.intel)
         cm.set_metadata("info.sbom", message.info.sbom)

--- a/src/cve/stages/build_vdb_stage.py
+++ b/src/cve/stages/build_vdb_stage.py
@@ -61,7 +61,7 @@ class BuildSourceCodeVdbStage(SinglePortStage):
             Accepted input types.
 
         """
-        return (AgentMorpheusInput, )
+        return (AgentMorpheusInput,)
 
     def compute_schema(self, schema: StageSchema):
         for (port_idx, port_schema) in enumerate(schema.input_schemas):
@@ -117,11 +117,11 @@ class BuildSourceCodeVdbStage(SinglePortStage):
 
         except Exception as e:
             # For now just skip the row
-            logger.error("Failure to build VDB for image, '%s', with source code info: %s\nError: %s",
-                         base_image,
-                         source_code_repos,
-                         e,
-                         exc_info=True)
+            logger.exception("Failure to build VDB for image, '%s', with source code info: %s\nError: %s",
+                             base_image,
+                             source_code_repos,
+                             e,
+                             exc_info=True)
 
             if not self._ignore_errors:
                 raise

--- a/src/cve/stages/convert_to_output_object.py
+++ b/src/cve/stages/convert_to_output_object.py
@@ -16,6 +16,8 @@
 
 import json
 import logging
+
+from ..utils.error_handling_decorator import catch_pipeline_errors
 from ..utils.loggers_factory import LoggingFactory, trace_id
 
 from morpheus.messages import ControlMessage
@@ -127,6 +129,7 @@ def _get_deficient_intel_output(vuln_id: str) -> AgentMorpheusEngineOutput:
         justification=JUSTIFICATION)
 
 
+@catch_pipeline_errors
 @stage
 def convert_to_output_object(message: ControlMessage) -> AgentMorpheusOutput:
     """

--- a/src/cve/stages/http_output_stage.py
+++ b/src/cve/stages/http_output_stage.py
@@ -15,8 +15,8 @@
 
 import base64
 from http import HTTPStatus
-import json5
 
+from ..utils.error_handling_decorator import catch_pipeline_errors
 from ..utils.loggers_factory import LoggingFactory, trace_id
 
 from pydantic import BaseModel
@@ -51,6 +51,7 @@ def get_auth_header(auth: AuthenticationMethodConfig | None) -> str | None:
             return None
 
 
+@catch_pipeline_errors
 @stage
 def http_output_stage(model: BaseModel, *, base_url: str, endpoint: str, auth: AuthenticationMethodConfig | None,
                       verify_path: str | None) -> BaseModel:

--- a/src/cve/utils/chain_of_calls_retriever.py
+++ b/src/cve/utils/chain_of_calls_retriever.py
@@ -309,7 +309,8 @@ class ChainOfCallsRetriever:
         else:
             return None
 
-    def print_call_hierarchy(self, call_hierarchy_list: list[Document]):
+    def print_call_hierarchy(self, call_hierarchy_list: list[Document]) ->list[str]:
+        results = []
         for i, package_function in enumerate(reversed(call_hierarchy_list)):
             packages_names = self.language_parser.get_package_names(package_function)
             if len(packages_names) > 1:
@@ -323,4 +324,9 @@ class ChainOfCallsRetriever:
             else:
                 package_name = package_function.metadata['source']
             function_name = self.language_parser.get_function_name(package_function)
-            logger.debug(f"(package={package_name},function={function_name},depth={i})")
+            current_level = f"(package={package_name},function={function_name},depth={i})"
+            results.append(current_level)
+
+        return results
+
+

--- a/src/cve/utils/clients/intel_client.py
+++ b/src/cve/utils/clients/intel_client.py
@@ -19,6 +19,7 @@ from abc import abstractmethod
 
 import aiohttp
 
+from ..loggers_factory import trace_id
 from ...utils.async_http_utils import request_with_retry
 
 
@@ -74,7 +75,7 @@ class IntelClient:
                       headers: dict[str, str] | None = None,
                       log_on_error=True,
                       **kwargs):
-
+        headers["traceId"] = trace_id.get()
         async with request_with_retry(session=self._session,
                                       request_kwargs={
                                           'method': method, 'url': url, "params": params, "headers": headers, **kwargs

--- a/src/cve/utils/clients/rhsa_client.py
+++ b/src/cve/utils/clients/rhsa_client.py
@@ -55,7 +55,8 @@ class RHSAClient(IntelClient):
     async def get_intel_dict(self, cve_id: str) -> dict:
         response = await self.request(method='GET',
                                       url=url_join(self.base_url, "securitydata", "cve.json"),
-                                      params={"ids": cve_id})
+                                      params={"ids": cve_id},
+                                      headers={})
 
         vulns = response
 
@@ -67,7 +68,8 @@ class RHSAClient(IntelClient):
             logger.warning(f"Found multiple Red Hat CVE entries for {cve_id}, using the first one")
 
         response_full = await self.request(method='GET',
-                                           url=url_join(self.base_url, "securitydata", f"cve/{cve_id}.json"))
+                                           url=url_join(self.base_url, "securitydata", f"cve/{cve_id}.json"),
+                                           headers={})
 
         return response_full
 

--- a/src/cve/utils/clients/ubuntu_client.py
+++ b/src/cve/utils/clients/ubuntu_client.py
@@ -52,7 +52,8 @@ class UbuntuClient(IntelClient):
     async def get_intel_dict(self, cve_id: str) -> dict:
         response = await self.request(method='GET',
                                       url=url_join(self.base_url, "security", "cves.json"),
-                                      params={"q": cve_id})
+                                      params={"q": cve_id},
+                                      headers={})
 
         # Get the vulnerabilities from the dict
         vulns = response.get("cves", [])

--- a/src/cve/utils/dep_tree.py
+++ b/src/cve/utils/dep_tree.py
@@ -99,11 +99,11 @@ class GoDependencyTreeBuilder(DependencyTreeBuilder):
 
     @staticmethod
     def get_go_mod_graph_tree(manifest_path) -> str:
-        return subprocess.run(["bash", "-c", f" cd {manifest_path} ; go mod graph -modfile {manifest_path}/go.mod"],
+        return subprocess.run(["bash", "-c", f" cd {manifest_path} ; export GOWORK=off ; go mod graph -modfile {manifest_path}/go.mod"],
                               capture_output=True, text=True).stdout
 
     def download_go_mod_vendor(self, manifest_path):
-        subprocess.run(["bash", "-c", f" cd {manifest_path} ; go mod vendor"])
+        subprocess.run(["bash", "-c", f" export GOWORK=off ; cd {manifest_path} ; go mod vendor"])
 
     def extract_package_name(self, package_name: str) -> str:
         if package_name.__contains__("@"):

--- a/src/cve/utils/error_handling_decorator.py
+++ b/src/cve/utils/error_handling_decorator.py
@@ -6,9 +6,11 @@ logger = LoggingFactory.get_agent_logger(__name__)
 
 
 def catch_pipeline_errors(func):
+    @functools.wraps(func)
     def catch_errors(*args, **kwargs):
         try:
-            logger.debug(f"ZviDebug-> before running function {func.__name__}, args={args} kwargs={kwargs}")
+            logger.debug(f"Before running function {func.__name__}")
+            # logger.debug(f"ZviDebug-> kwargs={kwargs}, args={args}")
             if (args == () and kwargs == {}) or (args is None and kwargs is None):
                 pass
             elif args == ():
@@ -28,8 +30,8 @@ def catch_pipeline_errors_methods_async_kwargs(func):
     @functools.wraps(func)
     async def catch_errors_methods(self, *args, **kwargs):
         try:
-            logger.debug(f"ZviDebug-> before running function {func.__name__}, args={args} kwargs={kwargs}")
-            logger.debug(f"ZviDebug-> kwargs={kwargs}")
+            logger.debug(f"Before running function {func.__name__}")
+            # logger.debug(f"ZviDebug-> kwargs={kwargs}, args={args}")
             return await func(self, **kwargs)
 
         except Exception as exc:

--- a/src/cve/utils/error_handling_decorator.py
+++ b/src/cve/utils/error_handling_decorator.py
@@ -8,17 +8,14 @@ logger = LoggingFactory.get_agent_logger(__name__)
 def catch_pipeline_errors(func):
     def catch_errors(*args, **kwargs):
         try:
+            logger.debug(f"ZviDebug-> before running function {func.__name__}, args={args} kwargs={kwargs}")
             if (args == () and kwargs == {}) or (args is None and kwargs is None):
-                logger.debug(f"ZviDebug-> 1, catch_pipeline_errors, function_name={func.__name__} ")
                 pass
             elif args == ():
-                logger.debug(f"ZviDebug-> 2,  catch_pipeline_errors, function_name={func.__name__} ")
                 return func(**kwargs)
             elif kwargs == {}:
-                logger.debug(f"ZviDebug-> 3,  catch_pipeline_errors, function_name={func.__name__} ")
                 return func(*args)
             else:
-                logger.debug(f"ZviDebug-> 4,  catch_pipeline_errors, function_name={func.__name__} ")
                 return func(*args, **kwargs)
         except Exception as exc:
             logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
@@ -27,54 +24,16 @@ def catch_pipeline_errors(func):
     return catch_errors
 
 
-def catch_pipeline_errors_methods(func):
-
-    def catch_errors_methods(self, *args, **kwargs):
-        try:
-            if (args == () and kwargs == {}) or (args is None and kwargs is None):
-                logger.debug(f"ZviDebug-> 1, catch_pipeline_errors, function_name={func.__name__} ")
-                pass
-            elif args == ():
-                logger.debug(f"ZviDebug-> 2,  catch_pipeline_errors, function_name={func.__name__} ")
-                return func(self, **kwargs)
-            elif kwargs == {}:
-                logger.debug(f"ZviDebug-> 3,  catch_pipeline_errors, function_name={func.__name__} ")
-                return func(self, *args)
-            else:
-                logger.debug(f"ZviDebug-> 4,  catch_pipeline_errors, function_name={func.__name__} ")
-                return func(self, *args, **kwargs)
-        except Exception as exc:
-            logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
-            raise
-
-    return catch_errors_methods
-
-
-def catch_pipeline_errors_methods_async_args(func):
-    @functools.wraps(func)
-    async def catch_errors_methods(self, args):
-        try:
-            logger.debug(f"ZviDebug-> args={args}")
-            # logger.debug(f"ZviDebug-> args={kwargs}")
-            return await func(*args)
-
-        except Exception as exc:
-            logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
-            raise
-
-    return catch_errors_methods
-
-
 def catch_pipeline_errors_methods_async_kwargs(func):
-    async def catch_errors_methods(args):
+    @functools.wraps(func)
+    async def catch_errors_methods(self, *args, **kwargs):
         try:
-            logger.debug(f"ZviDebug-> args={args}")
-            return await func(*args)
+            logger.debug(f"ZviDebug-> before running function {func.__name__}, args={args} kwargs={kwargs}")
+            logger.debug(f"ZviDebug-> kwargs={kwargs}")
+            return await func(self, **kwargs)
 
         except Exception as exc:
             logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
             raise
 
     return catch_errors_methods
-
-

--- a/src/cve/utils/error_handling_decorator.py
+++ b/src/cve/utils/error_handling_decorator.py
@@ -1,0 +1,56 @@
+from src.cve.utils.loggers_factory import LoggingFactory
+
+logger = LoggingFactory.get_agent_logger(__name__)
+
+
+def catch_pipeline_errors(func):
+    def catch_errors(*args, **kwargs):
+        try:
+            # logger.debug(f"ZviDebug -> catch_pipeline_errors from func{func.__name__}")
+            # logger.debug(f"ZviDebug-> args={args}")
+            # logger.debug(f"ZviDebug-> kwargs={kwargs}")
+            if (args == () and kwargs == {}) or (args is None and kwargs is None):
+                logger.debug(f"ZviDebug-> 1, catch_pipeline_errors, function_name={func.__name__} ")
+                pass
+            elif args == ():
+                logger.debug(f"ZviDebug-> 2,  catch_pipeline_errors, function_name={func.__name__} ")
+                return func(**kwargs)
+            elif kwargs == {}:
+                logger.debug(f"ZviDebug-> 3,  catch_pipeline_errors, function_name={func.__name__} ")
+                return func(*args)
+            else:
+                logger.debug(f"ZviDebug-> 4,  catch_pipeline_errors, function_name={func.__name__} ")
+                return func(*args, **kwargs)
+        except Exception as exc:
+            logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
+            raise
+
+    return catch_errors
+
+
+def catch_pipeline_errors_async(func):
+    logger.debug(f"ZviDebug Special -> catch_pipeline_errors_async from func{str(func)}, func details-->{vars(func)}")
+
+    async def catch_errors(*args, **kwargs):
+        try:
+            logger.debug(f"ZviDebug -> catch_pipeline_errors_async from func{func.__name__}")
+            logger.debug(f"ZviDebug-> args={args}")
+            logger.debug(f"ZviDebug-> kwargs={kwargs}")
+            if (args == () and kwargs == {}) or (args is None and kwargs is None):
+                pass
+                logger.debug(f"ZviDebug-> 1, catch_pipeline_errors_async, function_name={func.__name__} ")
+            elif len(args) == 0:
+                logger.debug(f"ZviDebug-> 2,  catch_pipeline_errors_async, function_name={func.__name__} ")
+                return await func(**kwargs)
+            elif kwargs == {}:
+                logger.debug(f"ZviDebug-> 3,  catch_pipeline_errors_async, function_name={func.__name__} ")
+                return await func(*args)
+            else:
+                logger.debug(f"ZviDebug-> 4,  catch_pipeline_errors_async function_name={func.__name__} ")
+                return await func(*args, **kwargs)
+
+        except Exception as exc:
+            logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
+            raise
+
+    return catch_errors

--- a/src/cve/utils/error_handling_decorator.py
+++ b/src/cve/utils/error_handling_decorator.py
@@ -1,3 +1,5 @@
+import functools
+
 from src.cve.utils.loggers_factory import LoggingFactory
 
 logger = LoggingFactory.get_agent_logger(__name__)
@@ -6,9 +8,6 @@ logger = LoggingFactory.get_agent_logger(__name__)
 def catch_pipeline_errors(func):
     def catch_errors(*args, **kwargs):
         try:
-            # logger.debug(f"ZviDebug -> catch_pipeline_errors from func{func.__name__}")
-            # logger.debug(f"ZviDebug-> args={args}")
-            # logger.debug(f"ZviDebug-> kwargs={kwargs}")
             if (args == () and kwargs == {}) or (args is None and kwargs is None):
                 logger.debug(f"ZviDebug-> 1, catch_pipeline_errors, function_name={func.__name__} ")
                 pass
@@ -28,29 +27,54 @@ def catch_pipeline_errors(func):
     return catch_errors
 
 
-def catch_pipeline_errors_async(func):
-    logger.debug(f"ZviDebug Special -> catch_pipeline_errors_async from func{str(func)}, func details-->{vars(func)}")
+def catch_pipeline_errors_methods(func):
 
-    async def catch_errors(*args, **kwargs):
+    def catch_errors_methods(self, *args, **kwargs):
         try:
-            logger.debug(f"ZviDebug -> catch_pipeline_errors_async from func{func.__name__}")
-            logger.debug(f"ZviDebug-> args={args}")
-            logger.debug(f"ZviDebug-> kwargs={kwargs}")
             if (args == () and kwargs == {}) or (args is None and kwargs is None):
+                logger.debug(f"ZviDebug-> 1, catch_pipeline_errors, function_name={func.__name__} ")
                 pass
-                logger.debug(f"ZviDebug-> 1, catch_pipeline_errors_async, function_name={func.__name__} ")
-            elif len(args) == 0:
-                logger.debug(f"ZviDebug-> 2,  catch_pipeline_errors_async, function_name={func.__name__} ")
-                return await func(**kwargs)
+            elif args == ():
+                logger.debug(f"ZviDebug-> 2,  catch_pipeline_errors, function_name={func.__name__} ")
+                return func(self, **kwargs)
             elif kwargs == {}:
-                logger.debug(f"ZviDebug-> 3,  catch_pipeline_errors_async, function_name={func.__name__} ")
-                return await func(*args)
+                logger.debug(f"ZviDebug-> 3,  catch_pipeline_errors, function_name={func.__name__} ")
+                return func(self, *args)
             else:
-                logger.debug(f"ZviDebug-> 4,  catch_pipeline_errors_async function_name={func.__name__} ")
-                return await func(*args, **kwargs)
+                logger.debug(f"ZviDebug-> 4,  catch_pipeline_errors, function_name={func.__name__} ")
+                return func(self, *args, **kwargs)
+        except Exception as exc:
+            logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
+            raise
+
+    return catch_errors_methods
+
+
+def catch_pipeline_errors_methods_async_args(func):
+    @functools.wraps(func)
+    async def catch_errors_methods(self, args):
+        try:
+            logger.debug(f"ZviDebug-> args={args}")
+            # logger.debug(f"ZviDebug-> args={kwargs}")
+            return await func(*args)
 
         except Exception as exc:
             logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
             raise
 
-    return catch_errors
+    return catch_errors_methods
+
+
+def catch_pipeline_errors_methods_async_kwargs(func):
+    async def catch_errors_methods(args):
+        try:
+            logger.debug(f"ZviDebug-> args={args}")
+            return await func(*args)
+
+        except Exception as exc:
+            logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
+            raise
+
+    return catch_errors_methods
+
+

--- a/src/cve/utils/intel_retriever.py
+++ b/src/cve/utils/intel_retriever.py
@@ -102,7 +102,7 @@ class IntelRetriever:
             intel.ghsa = await self._ghsa_client.get_intel(vuln_id=intel.vuln_id)
 
         except Exception as e:
-            logger.error("Error fetching GitHub security advisory for %s : %s", vuln_id, e)
+            logger.exception("Error fetching GitHub security advisory for %s : %s", vuln_id, e)
 
         return intel
 
@@ -118,7 +118,7 @@ class IntelRetriever:
             return intel.nvd
 
         except Exception as e:
-            logger.error("Error fetching NVD intel for %s : %s", intel.vuln_id, e)
+            logger.exception("Error fetching NVD intel for %s : %s", intel.vuln_id, e)
 
             return None
 
@@ -134,7 +134,7 @@ class IntelRetriever:
             return intel.ubuntu
 
         except Exception as e:
-            logger.error("Error fetching Ubuntu security advisory for %s : %s", intel.vuln_id, e)
+            logger.exception("Error fetching Ubuntu security advisory for %s : %s", intel.vuln_id, e)
 
             return None
 
@@ -150,7 +150,7 @@ class IntelRetriever:
             return intel.rhsa
 
         except Exception as e:
-            logger.error("Error fetching Red Hat security advisory for %s : %s", intel.vuln_id, e)
+            logger.exception("Error fetching Red Hat security advisory for %s : %s", intel.vuln_id, e)
 
             return None
 
@@ -165,7 +165,7 @@ class IntelRetriever:
 
             return intel.epss
         except Exception as e:
-            logger.error("Error fetching EPSS score for %s : %s", intel.vuln_id, e)
+            logger.exception("Error fetching EPSS score for %s : %s", intel.vuln_id, e)
 
             return None
 
@@ -176,7 +176,7 @@ class IntelRetriever:
             return intel.plugin_data
 
         except Exception as e:
-            logger.error("Error fetching data from plugin %s : %s", intel.vuln_id, e, exc_info=True)
+            logger.exception("Error fetching data from plugin %s : %s", intel.vuln_id, e, exc_info=True)
             return None
 
     async def retrieve(self, vuln_id: str) -> CveIntel:

--- a/src/cve/utils/loggers_factory.py
+++ b/src/cve/utils/loggers_factory.py
@@ -27,7 +27,8 @@ class LoggingFactory:
         logger = logging.getLogger(logger_name)
         logger.propagate = False
         handler = logging.StreamHandler(sys.stdout)
-        formatter = logging.Formatter('%(asctime)s - %(threadName)s- traceId=%(traceId)s - %(name)s - %(levelname)s -'
+        formatter = logging.Formatter('%(asctime)s - threadName=%(threadName)s- traceId=%(traceId)s - %(name)s - %('
+                                      'levelname)s -'
                                       ' %(message)s')
         handler.setFormatter(formatter)
         if len(logger.handlers) == 0:

--- a/src/cve/utils/source_code_git_loader.py
+++ b/src/cve/utils/source_code_git_loader.py
@@ -127,7 +127,7 @@ class SourceCodeGitLoader(BlobLoader):
 
         # Reliable way to check out the ref using a shallow clone
         repo.git.fetch("origin", self.ref, depth=1)
-        repo.git.checkout("FETCH_HEAD")
+        repo.git.checkout("FETCH_HEAD", force=True)
 
         logger.debug("Loaded Git repository at path: '%s' @ '%s'", self.repo_path, self.ref)
 

--- a/src/cve/utils/transitive_code_searcher_tool.py
+++ b/src/cve/utils/transitive_code_searcher_tool.py
@@ -95,21 +95,19 @@ class TransitiveCodeSearcher:
             logger.debug(f"error intercepted from COC Retriever =>{str(ex)}")
             return found_path, []
 
-        logger.debug("")
-        logger.debug(f"Retriever found path={found_path}")
-        logger.debug(f"path size={len(call_hierarchy_list)}")
-        logger.debug("")
-        logger.debug("==============================================")
-        logger.debug("Prints Hierarchy call functions path")
-        logger.debug("==============================================")
-        logger.debug("")
-        self.chain_of_calls_retriever.print_call_hierarchy(call_hierarchy_list)
-        logger.debug("Path Contents Content:")
-        logger.debug("==============================================")
-        logger.debug("")
+        path_details = self.chain_of_calls_retriever.print_call_hierarchy(call_hierarchy_list)
+        log_message = f"\n Retriever found path={found_path}\n path size={len(call_hierarchy_list)}\n" \
+                      f"==============================================\nPrints Hierarchy call functions " \
+                      f"path\n==============================================\n"
+
+        for node in path_details:
+            log_message = log_message + node + "\n"
+
+        logger.debug(log_message)
+        log_message_2 = "Path Contents Content: \n" + "==============================================\n"
+        content_of_files_in_path = f"{log_message_2}"
         for i, function_method in enumerate(reversed(call_hierarchy_list)):
-            logger.debug(f"File {i + 1}: {function_method.metadata['source']}")
-            logger.debug("-------------------------------------------")
-            logger.debug(function_method.page_content)
-        logger.debug(" ")
+            content_of_files_in_path = f"{content_of_files_in_path} File {i + 1}: {function_method.metadata['source']}\n" \
+                       f"-------------------------------------------\n{function_method.page_content}\n"
+            logger.debug(content_of_files_in_path)
         return found_path, call_hierarchy_list


### PR DESCRIPTION
**Description**

1. Propagate traceId of a request to all intel requests and to Nginx logs.
2. Prevent checkout failures in case of temp worktree changes.
3. Created  2 decorators that wrapping all stages of the agent' pipeline in order to intercept exceptions with the request id and log them.
4.  Propagate traceId to all LLM Engine stages
5. Catch all pipeline errors and associate it with the causing requestId (traceId).


Fixes Jira [APPENG-3110](https://issues.redhat.com/browse/APPENG-3110)