### PR TITLE
fix: support multi-line log messages

### DIFF
--- a/src/cve/nodes/cve_summary_node.py
+++ b/src/cve/nodes/cve_summary_node.py
@@ -84,22 +84,9 @@ class CVESummaryNode(LLMNode):
     # Concatenate the output of the checklist responses into a single string
     @catch_pipeline_errors_methods_async_kwargs
     async def concat_checklist_responses(self, agent_q_and_a: list[list[dict]]) -> list[str]:
-        logger.debug(f"before, trace_id assignment")
-        trace_id_var.set(self.trace_id_value)
-        logger.debug(f"after, trace_id assignment, trace_id={self.trace_id_value}")
-        concatted_responses = []
-
-        for checklist in agent_q_and_a:
-            checklist_str = '\n'.join([get_checklist_item_string(i + 1, item) for i, item in enumerate(checklist)])
-            concatted_responses.append(checklist_str)
-
-        return concatted_responses
-
-    # Concatenate the output of the checklist responses into a single string
-    @catch_pipeline_errors_methods_async_kwargs
-    async def concat_checklist_responses(self, agent_q_and_a: list[list[dict]]) -> list[str]:
         trace_id_var.set(self.trace_id_value)
         concatted_responses = []
+
         for checklist in agent_q_and_a:
             checklist_str = '\n'.join([get_checklist_item_string(i + 1, item) for i, item in enumerate(checklist)])
             concatted_responses.append(checklist_str)

--- a/src/cve/pipeline/input.py
+++ b/src/cve/pipeline/input.py
@@ -16,9 +16,10 @@
 
 import asyncio
 import logging
+import textwrap
 
 from ..utils.error_handling_decorator import catch_pipeline_errors
-from ..utils.loggers_factory import LoggingFactory, trace_id
+from ..utils.loggers_factory import LoggingFactory, trace_id, MULTI_LINE_MESSAGE_TRUE
 import os
 import typing
 
@@ -66,13 +67,6 @@ def build_http_input(pipe: LinearPipeline, config: Config, input: HttpInputConfi
     # Log to a file in the user's log directory next to morpheus logs
     log_file = os.path.join(appdirs.user_log_dir(appauthor="NVIDIA", appname="morpheus"), "http_server.log")
 
-    # Add a file handler
-    file_handler = logging.FileHandler(log_file)
-
-    # Set the format
-    file_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
-
-    http_server_logger.addHandler(file_handler)
     http_server_logger.setLevel(logging.INFO)
 
     http_server_logger.info(f"Http Server Started for {input.http_method.name} "
@@ -91,9 +85,10 @@ def build_http_input(pipe: LinearPipeline, config: Config, input: HttpInputConfi
     def print_payload(payload: typing.Any) -> typing.Any:
         assert isinstance(payload, BaseModel)
 
-        serialized_str = payload.model_dump_json(indent=2)
+        serialized_str = textwrap.dedent(payload.model_dump_json())
 
-        http_server_logger.info("======= Got Request =======\n%s\n===========================", serialized_str)
+        http_server_logger.info("======= Got Request =======\n %s \n===========================", serialized_str,
+                                extra=MULTI_LINE_MESSAGE_TRUE)
         return payload
 
     pipe.add_stage(print_payload(config))

--- a/src/cve/utils/error_handling_decorator.py
+++ b/src/cve/utils/error_handling_decorator.py
@@ -1,6 +1,6 @@
 import functools
 
-from src.cve.utils.loggers_factory import LoggingFactory
+from src.cve.utils.loggers_factory import LoggingFactory, MULTI_LINE_MESSAGE_TRUE
 
 logger = LoggingFactory.get_agent_logger(__name__)
 
@@ -20,7 +20,8 @@ def catch_pipeline_errors(func):
             else:
                 return func(*args, **kwargs)
         except Exception as exc:
-            logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
+            logger.exception(f"Intercepted a pipeline exception in function %s on file %s --> \n %s", func.__name__,
+                             func.__module__, exc, extra=MULTI_LINE_MESSAGE_TRUE)
             raise
 
     return catch_errors
@@ -33,9 +34,9 @@ def catch_pipeline_errors_methods_async_kwargs(func):
             logger.debug(f"Before running function {func.__name__}")
             # logger.debug(f"ZviDebug-> kwargs={kwargs}, args={args}")
             return await func(self, **kwargs)
-
         except Exception as exc:
-            logger.exception(f"Intercepted a pipeline exception in function %s --> \n %s", func.__name__, exc)
+            logger.exception(f"Intercepted a pipeline exception in function %s on file %s --> \n %s", func.__name__,
+                             func.__module__, exc, extra=MULTI_LINE_MESSAGE_TRUE)
             raise
 
     return catch_errors_methods

--- a/src/cve/utils/loggers_factory.py
+++ b/src/cve/utils/loggers_factory.py
@@ -1,14 +1,41 @@
 import logging
 import sys
+import textwrap
 from contextvars import ContextVar
 
+MULTI_LINE_MESSAGE = "MultiLineMessage"
+MULTI_LINE_MESSAGE_TRUE = {MULTI_LINE_MESSAGE: True}
 old_factory = logging.getLogRecordFactory()
 trace_id: ContextVar[str] = ContextVar('trace_id', default=' ')
+
+
+class AgentStreamHandler(logging.StreamHandler):
+
+    def __init__(self, stream=None):
+        super().__init__(stream)
+
+    def emit(self, record):
+        # escape new lines to remove from multi lines message logs end of lines, preserving only the \n character itself
+        # This one is in order to support multiline string messages to be logged in centralized logging in the same log
+        # record.
+        if record.__dict__.get("%s" % MULTI_LINE_MESSAGE, None):
+            record.msg = record.msg.replace("\n", "\\n")
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            stream.write(msg + self.terminator)
+            self.flush()
+        except RecursionError:
+            raise
+        except Exception:
+            self.handleError(record)
 
 
 def record_factory(*args, **kwargs):
     record = old_factory(*args, **kwargs)
     record.traceId = trace_id.get()
+    if kwargs.get("%s" % MULTI_LINE_MESSAGE, None):
+        record.message = textwrap.dedent(record.message)
     return record
 
 
@@ -26,7 +53,7 @@ class LoggingFactory:
 
         logger = logging.getLogger(logger_name)
         logger.propagate = False
-        handler = logging.StreamHandler(sys.stdout)
+        handler = AgentStreamHandler(sys.stdout)
         formatter = logging.Formatter('%(asctime)s - threadName=%(threadName)s- traceId=%(traceId)s - %(name)s - %('
                                       'levelname)s -'
                                       ' %(message)s')

--- a/src/cve/utils/loggers_factory.py
+++ b/src/cve/utils/loggers_factory.py
@@ -17,7 +17,7 @@ class AgentStreamHandler(logging.StreamHandler):
     def emit(self, record):
         # escape new lines to remove from multi lines message logs end of lines, preserving only the \n character itself
         # This one is in order to support multiline string messages to be logged in centralized logging in the same log
-        # record.
+        # record, withut being truncated after first new line.
         if record.__dict__.get("%s" % MULTI_LINE_MESSAGE, None):
             record.msg = record.msg.replace("\n", "\\n")
         try:

--- a/src/cve/utils/loggers_factory.py
+++ b/src/cve/utils/loggers_factory.py
@@ -18,10 +18,12 @@ class AgentStreamHandler(logging.StreamHandler):
         # escape new lines to remove from multi lines message logs end of lines, preserving only the \n character itself
         # This one is in order to support multiline string messages to be logged in centralized logging in the same log
         # record, withut being truncated after first new line.
-        if record.__dict__.get("%s" % MULTI_LINE_MESSAGE, None):
-            record.msg = record.msg.replace("\n", "\\n")
+        # if record.__dict__.get("%s" % MULTI_LINE_MESSAGE, None):
+        #     record.msg = record.msg.replace("\n", "\\n")
         try:
             msg = self.format(record)
+            if record.__dict__.get("%s" % MULTI_LINE_MESSAGE, None):
+                msg = msg.replace("\n", "\\n")
             stream = self.stream
             stream.write(msg + self.terminator)
             self.flush()

--- a/src/cve/utils/transitive_code_searcher_tool.py
+++ b/src/cve/utils/transitive_code_searcher_tool.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from .loggers_factory import LoggingFactory
+from .loggers_factory import LoggingFactory, MULTI_LINE_MESSAGE, MULTI_LINE_MESSAGE_TRUE
+
 import os
 import re
 from collections.abc import Iterable
@@ -92,7 +93,7 @@ class TransitiveCodeSearcher:
             call_hierarchy_list, found_path = self.chain_of_calls_retriever.get_relevant_documents(query)
         except ValueError as ex:
             found_path = False
-            logger.debug(f"error intercepted from COC Retriever =>{str(ex)}")
+            logger.debug(f"error intercepted from COC Retriever =>{str(ex)}", extra=MULTI_LINE_MESSAGE_TRUE)
             return found_path, []
 
         path_details = self.chain_of_calls_retriever.print_call_hierarchy(call_hierarchy_list)
@@ -103,11 +104,11 @@ class TransitiveCodeSearcher:
         for node in path_details:
             log_message = log_message + node + "\n"
 
-        logger.debug(log_message)
+        logger.debug(log_message,extra=MULTI_LINE_MESSAGE_TRUE)
         log_message_2 = "Path Contents Content: \n" + "==============================================\n"
         content_of_files_in_path = f"{log_message_2}"
         for i, function_method in enumerate(reversed(call_hierarchy_list)):
             content_of_files_in_path = f"{content_of_files_in_path} File {i + 1}: {function_method.metadata['source']}\n" \
                        f"-------------------------------------------\n{function_method.page_content}\n"
-            logger.debug(content_of_files_in_path)
+            logger.debug(content_of_files_in_path, extra=MULTI_LINE_MESSAGE_TRUE)
         return found_path, call_hierarchy_list


### PR DESCRIPTION
# Background

Multi-line string Log messages that are being sent by the vector collector ( Via the ClusterLogForwarder CR ) in openshift cluster logging, are shown truncated with only the first line of log message displayed.

# Solution:
  Introduce a feature in the agent service that will give the opportunity to log multi-line string message, using the special `extra` kwarg dict containing a new key value handled internally  by the agent, to escpace all new lines, so they will not get truncated when forwarded to external systems ( later one can escape them again in order to revive new lines again and visualize them more nicely, or if it's json, beautify the json .).

Code Example Usage:
```python

from ..utils.loggers_factory import LoggingFactory, trace_id, MULTI_LINE_MESSAGE_TRUE
logger = LoggingFactory.get_agent_logger(__name__)
http_server_logger.info("======= Got Request =======\n %s \n===========================",multiline_str ,
                                extra=MULTI_LINE_MESSAGE_TRUE)