### PR TITLE
fix: CVSS score impacted by incorrect fallback and mistaken final answer

### DIFF
--- a/src/cve/nodes/cve_cvss_node.py
+++ b/src/cve/nodes/cve_cvss_node.py
@@ -47,10 +47,10 @@ class CVECVSSNode(LLMNodeBase):
             "metric_abbreviation": "AV",
             "question": "Where can the attack be executed from?",
             "values": [
-                {"value": "Network", "abbreviation": "N", "definition": "Remote attack over the internet."},
-                {"value": "Adjacent", "abbreviation": "A", "definition": "Requires local network access."},
-                {"value": "Local", "abbreviation": "L", "definition": "Requires local access to the system."},
-                {"value": "Physical", "abbreviation": "P", "definition": "Requires physical access."}
+                {"value": "Network", "abbreviation": "N", "definition": "Remote attack over the internet.", "least_impact": False},
+                {"value": "Adjacent", "abbreviation": "A", "definition": "Requires local network access.", "least_impact": False},
+                {"value": "Local", "abbreviation": "L", "definition": "Requires local access to the system.", "least_impact": False},
+                {"value": "Physical", "abbreviation": "P", "definition": "Requires physical access.", "least_impact": True}
             ]
         },
         {
@@ -58,8 +58,8 @@ class CVECVSSNode(LLMNodeBase):
             "metric_abbreviation": "AC",
             "question": "How difficult is the attack to execute?",
             "values": [
-                {"value": "Low", "abbreviation": "L", "definition": "The attack is straightforward."},
-                {"value": "High", "abbreviation": "H", "definition": "The attack requires special conditions."}
+                {"value": "Low", "abbreviation": "L", "definition": "The attack is straightforward.", "least_impact": False},
+                {"value": "High", "abbreviation": "H", "definition": "The attack requires special conditions.", "least_impact": True}
             ]
         },
         {
@@ -67,9 +67,9 @@ class CVECVSSNode(LLMNodeBase):
             "metric_abbreviation": "PR",
             "question": "What level of access does the attacker need?",
             "values": [
-                {"value": "None", "abbreviation": "N", "definition": "No privileges needed."},
-                {"value": "Low", "abbreviation": "L", "definition": "Basic user privileges needed."},
-                {"value": "High", "abbreviation": "H", "definition": "Administrative privileges needed."}
+                {"value": "None", "abbreviation": "N", "definition": "No privileges needed.", "least_impact": False},
+                {"value": "Low", "abbreviation": "L", "definition": "Basic user privileges needed.", "least_impact": False},
+                {"value": "High", "abbreviation": "H", "definition": "Administrative privileges needed.", "least_impact": True}
             ]
         },
         {
@@ -77,8 +77,8 @@ class CVECVSSNode(LLMNodeBase):
             "metric_abbreviation": "UI",
             "question": "Does the attack require user action?",
             "values": [
-                {"value": "None", "abbreviation": "N", "definition": "No user interaction needed."},
-                {"value": "Required", "abbreviation": "R", "definition": "Requires user action."}
+                {"value": "None", "abbreviation": "N", "definition": "No user interaction needed.", "least_impact": False},
+                {"value": "Required", "abbreviation": "R", "definition": "Requires user action.", "least_impact": True}
             ]
         },
         {
@@ -87,9 +87,9 @@ class CVECVSSNode(LLMNodeBase):
             "question": "Does the attack affect other components or systems?",
             "values": [
                 {"value": "Unchanged", "abbreviation": "U",
-                 "definition": "The impact is limited to the vulnerable system."},
+                 "definition": "The impact is limited to the vulnerable system.", "least_impact": True},
                 {"value": "Changed", "abbreviation": "C",
-                 "definition": "The impact extends beyond the vulnerable system."}
+                 "definition": "The impact extends beyond the vulnerable system.", "least_impact": False}
             ]
         },
         {
@@ -97,9 +97,9 @@ class CVECVSSNode(LLMNodeBase):
             "metric_abbreviation": "C",
             "question": "Does the attack expose sensitive data?",
             "values": [
-                {"value": "None", "abbreviation": "N", "definition": "No impact on data confidentiality."},
-                {"value": "Low", "abbreviation": "L", "definition": "Partial exposure of non-sensitive data."},
-                {"value": "High", "abbreviation": "H", "definition": "Full exposure of sensitive data."}
+                {"value": "None", "abbreviation": "N", "definition": "No impact on data confidentiality.", "least_impact": True},
+                {"value": "Low", "abbreviation": "L", "definition": "Partial exposure of non-sensitive data.", "least_impact": False},
+                {"value": "High", "abbreviation": "H", "definition": "Full exposure of sensitive data.", "least_impact": False}
             ]
         },
         {
@@ -107,9 +107,9 @@ class CVECVSSNode(LLMNodeBase):
             "metric_abbreviation": "I",
             "question": "Can the attacker modify critical data?",
             "values": [
-                {"value": "None", "abbreviation": "N", "definition": "No impact on data integrity."},
-                {"value": "Low", "abbreviation": "L", "definition": "Limited unauthorized modifications."},
-                {"value": "High", "abbreviation": "H", "definition": "Complete control over data integrity."}
+                {"value": "None", "abbreviation": "N", "definition": "No impact on data integrity.", "least_impact": True},
+                {"value": "Low", "abbreviation": "L", "definition": "Limited unauthorized modifications.", "least_impact": False},
+                {"value": "High", "abbreviation": "H", "definition": "Complete control over data integrity.", "least_impact": False}
             ]
         },
         {
@@ -117,9 +117,9 @@ class CVECVSSNode(LLMNodeBase):
             "metric_abbreviation": "A",
             "question": "Does the attack affect system uptime?",
             "values": [
-                {"value": "None", "abbreviation": "N", "definition": "No impact on system availability."},
-                {"value": "Low", "abbreviation": "L", "definition": "Minor service degradation."},
-                {"value": "High", "abbreviation": "H", "definition": "Complete system failure."}
+                {"value": "None", "abbreviation": "N", "definition": "No impact on system availability.", "least_impact": True},
+                {"value": "Low", "abbreviation": "L", "definition": "Minor service degradation.", "least_impact": False},
+                {"value": "High", "abbreviation": "H", "definition": "Complete system failure.", "least_impact": False}
             ]
         }
     ]

--- a/src/cve/nodes/cve_cvss_node.py
+++ b/src/cve/nodes/cve_cvss_node.py
@@ -133,22 +133,24 @@ class CVECVSSNode(LLMNodeBase):
 
         self._create_agent_executor_fn = create_agent_executor_fn
 
-        self._input_names = ["checklist_outputs", "intermediate_steps"]
+        self._input_names = ["rhsa_statement", "checklist_outputs", "intermediate_steps"]
 
     def get_input_names(self):
         return self._input_names
 
     @staticmethod
-    def _parse_checklist_output(checklist_outputs: list[list[str]], intermediate_steps: list[list[list]]) -> list[
-        list[dict]]:
+    def _parse_checklist_output(checklist_outputs: list[list[str]], intermediate_steps: list[list[list]], rhsa_statement: list[str]) -> dict:
         checklist_data = []
 
         for check_out, steps in zip(checklist_outputs, intermediate_steps):
             checklist_data.append([{
                 "response": r, "intermediate_steps": s
             } for r, s in zip(check_out, steps)])  # yapf: disable
-
-        return checklist_data
+            
+        return {
+            "analysis_data": checklist_data,
+            "vulnerability_context": rhsa_statement
+        }
 
     def _postprocess_results(self, results: list[list[dict]]) -> dict[str, str]:
         outputs = []
@@ -188,9 +190,10 @@ class CVECVSSNode(LLMNodeBase):
         trace_id.set(context.message().get_metadata("input").scan.id)
         input_lst: list = self.DEFAULT_CVSS_METRICS_LIST
 
+        rhsa_statement: list[str] = context.get_input("rhsa_statement")
         checklist_outputs: list[list[str]] = context.get_input("checklist_outputs")
         intermediate_steps: list[list[list]] = context.get_input("intermediate_steps")
-        checklist_data: list[list[dict]] = self._parse_checklist_output(checklist_outputs, intermediate_steps)
+        checklist_data: dict = self._parse_checklist_output(checklist_outputs, intermediate_steps, rhsa_statement)
 
         agent = self._create_agent_executor_fn(context, checklist_data)
         tasks = [self._run_single(agent=agent, item=item) for item in input_lst]

--- a/src/cve/pipeline/engine.py
+++ b/src/cve/pipeline/engine.py
@@ -136,10 +136,10 @@ def _create_notify_handler(run_config: RunConfig):
 
 def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientWrapper | ChatOpenAI,
                          embeddings: Embeddings):
-    def inner_create_agent_fn(context: LLMContext, analysis_data: list[list[dict]]):
+    def inner_create_agent_fn(context: LLMContext, analysis_data: dict):
         trace_id.set(context.message().get_metadata("input").scan.id)
 
-        def get_analysis_data(query: str) -> list[list[dict]]:
+        def get_analysis_data(query: str) -> dict:
             """
             Fetches the container image analysis data.
             """
@@ -218,8 +218,10 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
                     "Useful when you need to retrieve information from the analysis data of a container image. "
                     "This tool does not perform new analysis, but only returns pre-analyzed data based on a prior scan. "
                     "This tool is especially useful when your task involves understanding how the container image may be impacted by a reported CVE. "
-                    "The tool provides structured information about the container image's source code. "
-                    "The tool returns a list of analysis results, where each item in the list is an object describing a specific finding. "
+                    "The tool provides structured information about the container image's source code and context on the reported CVE. "
+                    "The tool returns an object with two fields:\n"
+                    "- vulnerability_context: a list of context statements on the reported CVE (or `null` if none are provided).\n"
+                    "- analysis_data: a list of the container image's source code analysis results, where each item in the list is an object describing a specific finding. "
                     "Each object in the list includes a 'response' field containing a concise summary of the analysis findings, and an optional 'intermediate_steps' field, which may contain reasoning or supporting details if not null. "
                 ),
             ),
@@ -252,7 +254,7 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
             "Answer the following questions as best you can.",
             "To answer the following question, use the tools available to you to select the most appropriate CVSS metric value.\n"
             "The Container Image Analysis Data should be your primary reference for making this selection.\n"
-            "If the container image analysis data does not contain the necessary information to make a selection, use other tools available to you to gather the required information from the container image.\n"
+            "If the Container Image Analysis Data does not contain the necessary information to make a selection, use other tools available to you to gather the required information from the container image.\n"
             "Your goal is to make the most accurate selection of the CVSS metric value based on the available evidence. Analyze and reason through the data you have access to — do not guess or default prematurely.\n"
             "Only if you have thoroughly evaluated all available tools and resources, and still cannot make a confident selection, may you choose the option where least_impact: True as a fallback.\n"
             "IMPORTANT: You must not call the same tool with the same input twice. Always try a different input or tool if your first attempt did not get a definitive answer.\n\n",
@@ -534,7 +536,7 @@ def build_engine(*, run_config: RunConfig, embeddings: Embeddings):
 
     if run_config.general.generate_cvss_score:
         engine.add_node("cvss",
-                        inputs=[("/agent/outputs", "checklist_outputs"), "/agent/intermediate_steps"],
+                        inputs=[("/extract_prompt/rhsa_statement", "rhsa_statement"), ("/agent/outputs", "checklist_outputs"), "/agent/intermediate_steps"],
                         node=CVECVSSNode(
                             create_agent_executor_fn=_build_cvss_agent_fn(run_config, wrapper_llm, embeddings),
                         ))

--- a/src/cve/pipeline/engine.py
+++ b/src/cve/pipeline/engine.py
@@ -220,7 +220,7 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
                     "This tool is especially useful when your task involves understanding how the container image may be impacted by a reported CVE. "
                     "The tool provides structured information about the container image's source code. "
                     "The tool returns a list of analysis results, where each item in the list is an object describing a specific finding. "
-                    "Each object in the list includes a 'response' field containing a concise summary of the analysis findings, and and optional 'intermediate_steps' field, which may contain reasoning or supporting details if not null. "
+                    "Each object in the list includes a 'response' field containing a concise summary of the analysis findings, and an optional 'intermediate_steps' field, which may contain reasoning or supporting details if not null. "
                 ),
             ),
         )
@@ -254,7 +254,7 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
             "The Container Image Analysis Data should be your primary reference for making this selection.\n"
             "If the container image analysis data does not contain the necessary information to make a selection, use other tools available to you to gather the required information from the container image.\n"
             "Your goal is to make the most accurate selection of the CVSS metric value based on the available evidence. Analyze and reason through the data you have access to — do not guess or default prematurely.\n"
-            "Only if you have thoroughly evaluated all available tools and resources, and still cannot make a confident selection, may you choose the least impact option as a fallback."
+            "Only if you have thoroughly evaluated all available tools and resources, and still cannot make a confident selection, may you choose the option where least_impact: True as a fallback.\n"
             "IMPORTANT: You must not call the same tool with the same input twice. Always try a different input or tool if your first attempt did not get a definitive answer.\n\n",
             1
         ).replace(
@@ -266,6 +266,12 @@ def _build_cvss_agent_fn(run_config: RunConfig, wrapper_llm: LangchainLLMClientW
             "Question: the input question you must answer",
             "Metric: the input metric you are evaluating in the following format: metric_name (metric_abbreviation)\n"
             "Question: the input question you must answer"
+        ).replace(
+            "Thought: I now know the final answer",
+            "Thought: I now know the final answer"
+            "I must end my Thought with exactly:\n"
+            "Selected: <value> (<abbreviation>)\n"
+            "and my Final Answer must reuse that same <abbreviation> verbatim.\n"
         ).replace(
             "Final Answer: the final answer to the original input question",
             "Final Answer: the final answer to the original input question. The final answer must follow this format: <metric_abbreviation>:<value_abbreviation>\n\n"


### PR DESCRIPTION
1. Incorrect Fallback value - In case the agent didnt know the answer, the least impact value which was chosen was usually incorrect, indicating the fallback value for each metric fixed this problem.
2. Mistaken final answer - Agent stated a chosen value in the though section but set a different value in the final answer, fixed by tweaking the prompt. 
3. Due to insufficient Context Window size, the agent cannot receive context on the CVE details in order to understand when a checklist item indicates that the code is not vulnerable, therefore it evaluates metrics only according to raw data seen in the checklist responses.  Added RHSA statement as additional context to the agent to provide a wider information pool while still inside CW scope