### PR TITLE
fix: remove spaces in cvss agents final answer

### DIFF
--- a/src/cve/nodes/cve_cvss_node.py
+++ b/src/cve/nodes/cve_cvss_node.py
@@ -151,7 +151,7 @@ class CVECVSSNode(LLMNodeBase):
 
         return checklist_data
 
-    def _postprocess_results(self, results: list[list[dict]]) -> dict[str, str]:
+    def _postprocess_results(self, results: list[list[dict]]) -> tuple[str, str]:
         outputs = []
         pattern = r'\s*[A-Z\s]+\s*:\s*[A-Z\s]+\s*'
 


### PR DESCRIPTION
CVSS agent provided final answer with redundant spaces (ex: I: L instead of I:L) which resulted in vector string calculation to fail due to bad format. Vector string validated using regex and  spaces removed if applicable.