### PR TITLE
chore: fix bug in developer and batch-processing overlays 

### DIFF
--- a/kustomize/overlays/batch-processing/kustomization.yaml
+++ b/kustomize/overlays/batch-processing/kustomization.yaml
@@ -25,7 +25,6 @@ patchesStrategicMerge:
         spec:
           containers:
             - name: agent-morpheus
-              image: quay.io/ecosystem-appeng/agent-morpheus-rh:latest
               imagePullPolicy: Always
               workingDir: /workspace/
               # Deploy with QoS(Guaranteed)
@@ -64,7 +63,6 @@ patchesStrategicMerge:
           serviceAccountName: morpheus-client-sa
           containers:
             - name: agent-morpheus-client
-              image: quay.io/ecosystem-appeng/agent-morpheus-client:latest
               imagePullPolicy: Always
               env:
                 - name: MORPHEUS_QUEUE_TIMEOUT

--- a/kustomize/overlays/developer/kustomization.yaml
+++ b/kustomize/overlays/developer/kustomization.yaml
@@ -30,7 +30,6 @@ patchesStrategicMerge:
         spec:
           containers:
             - name: agent-morpheus
-              image: quay.io/ecosystem-appeng/agent-morpheus-rh:latest
               imagePullPolicy: Always
               workingDir: /workspace/
               env:


### PR DESCRIPTION
In which the image transformer in base overlay' kustomization file is overriden by latest all the time