### PR TITLE
chore: add deployment variants metadata annotations

### DIFF
--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
   - agent_morpheus_client.yaml
   - agent_morpheus_jaeger.yaml
 
+commonAnnotations:
+  deployment-variant: base
+
 generatorOptions:
   disableNameSuffixHash: false
 

--- a/kustomize/overlays/batch-processing/kustomization.yaml
+++ b/kustomize/overlays/batch-processing/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
 - ../local-llama3.1-70b-4bit/
 
+
+commonAnnotations:
+  deployment-variant: batch-processing
+
 patchesStrategicMerge:
   - |- 
     apiVersion: apps/v1

--- a/kustomize/overlays/developer/kustomization.yaml
+++ b/kustomize/overlays/developer/kustomization.yaml
@@ -48,6 +48,9 @@ patchesStrategicMerge:
                   secretKeyRef:
                     name: langsmith-secret
                     key: langchainApiKey   
+                    
+              - name: EXTENDED_VERBOSE_DEBUG
+                value: "True"
                 
               args:
                 - "sleep"

--- a/kustomize/overlays/developer/kustomization.yaml
+++ b/kustomize/overlays/developer/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 resources:
 - ../local-llama3.1-70b-4bit/
 
+commonAnnotations:
+  deployment-variant: developer
+
 secretGenerator:
   - name: langsmith-secret
     envs:

--- a/kustomize/overlays/local-llama3.1-70b-4bit/kustomization.yaml
+++ b/kustomize/overlays/local-llama3.1-70b-4bit/kustomization.yaml
@@ -4,6 +4,10 @@ kind: Kustomization
 resources:
   - ../../base
 
+
+commonAnnotations:
+  deployment-variant: local-llama3.1-70b-4bit
+
 configMapGenerator:
   - name: agent-morpheus-config
     behavior: replace

--- a/kustomize/overlays/remote-nim-all/kustomization.yaml
+++ b/kustomize/overlays/remote-nim-all/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 resources:
   - ../../base
 
+commonAnnotations:
+  deployment-variant: remote-nim
+
 configMapGenerator:
   - name: agent-morpheus-config
     behavior: replace

--- a/src/cve/nodes/cve_cvss_node.py
+++ b/src/cve/nodes/cve_cvss_node.py
@@ -25,7 +25,7 @@ from morpheus_llm.llm import LLMContext
 from morpheus_llm.llm import LLMNodeBase
 
 from ..utils.error_handling_decorator import catch_pipeline_errors_methods_async
-from ..utils.loggers_factory import LoggingFactory, trace_id
+from ..utils.loggers_factory import LoggingFactory, trace_id, MULTI_LINE_MESSAGE_TRUE
 from ..utils.tracing import traced, record_attribute
 
 logger = LoggingFactory.get_agent_logger(__name__)


### PR DESCRIPTION
Also handles:

1. Fix omitted dict import.
2. Set EXTENDED_VERBOSE_DEBUG=True by default for developer overlay for extended debug logging for debugging and troubleshooting.