### PR TITLE
chore: make code search tool the default for remote-nim deployment

### DIFF
--- a/kustomize/overlays/remote-nim-all/agent-morpheus-config.json
+++ b/kustomize/overlays/remote-nim-all/agent-morpheus-config.json
@@ -72,6 +72,8 @@
     "use_uvloop": true,
     "use_dependency_checker": false,
     "retry_on_client_errors": false,
+    "transitive_code_search": true,
+    "code_search_tool": true,
     "generate_cvss_score": true,
     "generate_intel_score": true,
     "intel_low_score": 51,


### PR DESCRIPTION
# Background and reason

FAISS VDB Embedding is very slow for big git repositories snapshots, and for some of them, it even crashes after 6-8 minutes of processing. hence turn the default configuration for remote-nim deployment variant to use lexical code search instead of VDB Embedding.