### PR TITLE
chore: add Makefile for unified linting and test automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ LLM_METRICS_TEST_FILE ?= tests/integration/generate_metrics.py
 # Target branch for PR diffs in CI (override via `make lint-pr TARGET_BRANCH=develop`)
 TARGET_BRANCH ?= rh-main
 
+# Git remote for PR diffs in CI (override via `make lint-pr GIT_REMOTE=upstream`)
+GIT_REMOTE ?= origin
+
 # The pylint executable (override via `make lint PYLINT=pylint3`)
 PYLINT ?= pylint
 # The pytest executable (override via `make test PYTEST=pytest-xdist`)
@@ -50,9 +53,9 @@ lint-staged: ## Lint staged files.
 	}
 
 lint-pr: ## Lint PR changes (for CI).
-	@echo "--- Linting changed files in PR against origin/$(TARGET_BRANCH) ---"
+	@echo "--- Linting changed files in PR against $(GIT_REMOTE)/$(TARGET_BRANCH) ---"
 	@{ \
-		FILES_TO_LINT=$$(git diff --name-only "origin/$(TARGET_BRANCH)..." -- '*.py' ':(exclude)*/__init__.py'); \
+		FILES_TO_LINT=$$(git diff --name-only "$(GIT_REMOTE)/$(TARGET_BRANCH)..." -- '*.py' ':(exclude)*/__init__.py'); \
 		if [ -z "$$FILES_TO_LINT" ]; then \
 			echo "No changed Python files in this PR. Skipping."; \
 		else \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+# Ensure a consistent shell is used, avoiding potential issues with environment inheritance.
+# https://www.gnu.org/software/make/manual/make.html#Makefile-Basics
+SHELL = /bin/sh
+# Clear the list of suffixes to disable built-in implicit rules.
+.SUFFIXES:
+
+# Directory for the main source code (override via `make lint-all SRC_DIR=./app`)
+SRC_DIR ?= src
+# Path to the LLM metrics test file
+LLM_METRICS_TEST_FILE ?= tests/integration/generate_metrics.py
+
+# Target branch for PR diffs in CI (override via `make lint-pr TARGET_BRANCH=develop`)
+TARGET_BRANCH ?= rh-main
+
+# The pylint executable (override via `make lint PYLINT=pylint3`)
+PYLINT ?= pylint
+# The pytest executable (override via `make test PYTEST=pytest-xdist`)
+PYTEST ?= pytest
+# Extra options for pylint (override via `make lint PYLINT_OPTS="--disable=C0114"`)
+PYLINT_OPTS ?=
+# Extra options for pytest (override via `make test PYTEST_OPTS="-v -s --maxfail=1"`)
+PYTEST_OPTS ?=
+
+.PHONY: help lint lint-all lint-staged lint-pr test test-unit test-llm-metrics test-integration check
+
+# Set the default target to "help"
+.DEFAULT_GOAL := help
+
+help: ## Display this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+	awk 'BEGIN {FS = ":.*## "}; {printf "\t%-20s %s\n", $$1, $$2}'
+
+lint: lint-staged ## Lint staged files (default).
+
+lint-all: ## Lint all source files.
+	@echo "--- Linting all source files ---"
+	@$(PYLINT) $(PYLINT_OPTS) $(SRC_DIR)
+
+lint-staged: ## Lint staged files.
+	@echo "--- Linting staged files ---"
+	@{ \
+		FILES_TO_LINT=$$(git diff --name-only --cached --diff-filter=ACMRTUXB -- '*.py' ':(exclude)*/__init__.py'); \
+		if [ -z "$$FILES_TO_LINT" ]; then \
+			echo "No Python files staged for commit. Skipping."; \
+		else \
+			echo "Linting files:"; \
+			echo "$$FILES_TO_LINT" | sed 's/^/  /'; \
+			$(PYLINT) $(PYLINT_OPTS) $$FILES_TO_LINT; \
+		fi \
+	}
+
+lint-pr: ## Lint PR changes (for CI).
+	@echo "--- Linting changed files in PR against origin/$(TARGET_BRANCH) ---"
+	@{ \
+		FILES_TO_LINT=$$(git diff --name-only "origin/$(TARGET_BRANCH)..." -- '*.py' ':(exclude)*/__init__.py'); \
+		if [ -z "$$FILES_TO_LINT" ]; then \
+			echo "No changed Python files in this PR. Skipping."; \
+		else \
+			echo "Linting files:"; \
+			echo "$$FILES_TO_LINT" | sed 's/^/  /'; \
+			$(PYLINT) $(PYLINT_OPTS) $$FILES_TO_LINT; \
+		fi \
+	}
+
+test: test-unit test-llm-metrics ## Run all tests.
+	@echo "All tests have been run."
+
+test-unit: ## Run unit tests.
+	@echo "Running unit tests in $(SRC_DIR)..."
+	@python -m pytest $(SRC_DIR) $(PYTEST_OPTS)
+
+test-llm-metrics: ## Run LLM metrics tests.
+	@echo "Running LLM metrics tests..."
+	@python -m pytest $(LLM_METRICS_TEST_FILE) $(PYTEST_OPTS)
+
+test-integration: ## Run integration tests (placeholder).
+	@echo "--- SKIPPING: Integration tests are not yet implemented. ---"
+
+check: lint-all test  ## Lint all files and run all tests.
+	@echo "Lint and all tests have been run."


### PR DESCRIPTION
This PR add Makefile for unified linting and test automation
Linter issues do not cause pipeline failures during migration as Pylint runs in advisory mode only.
The linter configuration is now maintained in `pyproject.toml` (see https://github.com/RHEcosystemAppEng/vulnerability-analysis/pull/77).
