### PR TITLE
fix: handle null intermediate_steps in checklist_response metrics

### DIFF
--- a/metrics_lib/reports/checklist_response.py
+++ b/metrics_lib/reports/checklist_response.py
@@ -42,7 +42,9 @@ class ChecklistResponseMetrics:
                 for check in output["checklist"]:
                     answer = check["response"]
                     question = check["input"]
-                    thought_process_result_lst = [step["tool_output"] for step in check["intermediate_steps"]]
+                    # Handle case where intermediate_steps might be None
+                    intermediate_steps = check.get("intermediate_steps") or []
+                    thought_process_result_lst = [step["tool_output"] for step in intermediate_steps if step and "tool_output" in step]
                     thought_process_result_str = ', '.join(thought_process_result_lst)
                     data = {
                         "user_input": question,


### PR DESCRIPTION
Integration tests were failing with `TypeError: 'NoneType' object is not iterable` when processing checklist responses where the `intermediate_steps` field was `null`.
The example of such a report available in self-hosted env, report_id is `4c05e6b00c0ebeb657dff69e122fcb76`

```json

{
    "output": [
    {
        "vuln_id": "CVE-2024-3744",
        "checklist": [
            {
                "input": "Verif..... tokens.",
                "response": "The `....ens.",
                "intermediate_steps": null
            },
            {
                "input": "Inspect Loggin...okens?",
                "response": "I do not have....ct.",
                "intermediate_steps": null
            },
            {
                "input": "Assess L....logs.",
                "response": "Based ....on.",
                "intermediate_steps": null
            }
        ],
        "summary": "Based on the p...t.",
        "justification": {
            "label": "requires_configuration",
            "reason": "The ...ed.",
            "status": "FALSE"
        },
        "cvss": null,
        "intel_score": 65
    }
]
}
```