### PR TITLE
ci: add lint and unit test stages to CI pipelines

### DIFF
--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -78,7 +78,7 @@ spec:
             value: $(params.revision)
       - name: buildah-pvc
         runAfter:
-          - fetch-repository
+          - lint-and-test
         params:
           - name: IMAGE
             value: $(params.output-image)
@@ -123,6 +123,85 @@ spec:
 
           - name: buildah-temp-cache
             workspace: buildah-temp-cache
+      - name: lint-and-test
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source
+        taskSpec:
+          workspaces:
+            - name: source
+          volumes:
+            - name: env-file-volume
+              secret:
+                secretName: integration-tests-env-file
+            - name: examples-volume
+              configMap:
+                name: integration-tests-reports
+          steps:
+            - name: lint-test
+              env:
+                - name: PIP_ROOT_USER_ACTION
+                  value: "ignore"
+                - name: AGENT_MORPHEUS_TRACING_ENABLED
+                  value: "false"
+              image: docker.io/condaforge/miniforge3:latest
+              workingDir: $(workspaces.source.path)
+              volumeMounts:
+                - name: env-file-volume
+                  mountPath: $(workspaces.source.path)/.env
+                  subPath: .env
+                - name: examples-volume
+                  mountPath: $(workspaces.source.path)/examples
+              script: |
+                #!/bin/bash
+                
+                set -eo pipefail 
+
+                ENV_NAME="test-env"
+                CONDA_PKGS="make pylint pytest pytest-asyncio pytest-dotenv python-dotenv openpyxl ragas seaborn"
+                PIP_PKGS="langchain_nvidia_ai_endpoints==0.2.0"
+
+                print_banner() {
+                    echo
+                    echo "----------- ${1} -----------"
+                }
+
+                print_banner "CHECKING FOR .ENV FILE"
+                if [ -f .env ]; then
+                    echo ".env file successfully mounted."
+                else
+                    echo "ERROR: .env file not found!"
+                    exit 1
+                fi
+
+                print_banner "CHECKING FOR EXAMPLES DIR"
+                if [ -d "examples" ] && [ -n "$(ls -A examples)" ]; then
+                    echo "Examples directory successfully mounted."
+                else
+                    echo "ERROR: Examples directory not found or is empty!"
+                    exit 1
+                fi
+
+                print_banner "CREATING TEST ENV"
+                mamba env create --log-level error -q -y -f requirements.yaml -n "${ENV_NAME}"
+
+                print_banner "ACTIVATING CONDA ENV"
+                eval "$(mamba shell hook -s bash)"
+                mamba activate "${ENV_NAME}"
+
+                print_banner "INSTALLING TEST DEPENDENCIES"
+                mamba install --log-level error -q -y -c conda-forge ${CONDA_PKGS}
+                pip install -q ${PIP_PKGS}
+
+                print_banner "RUNNING LINTER"
+                make lint-pr
+
+                print_banner "RUNNING UNIT TESTS"
+                make test-unit
+
+                print_banner "LINT AND TEST COMPLETE"
   workspaces:
   - name: source
     volumeClaimTemplate:

--- a/.tekton/on-push.yaml
+++ b/.tekton/on-push.yaml
@@ -71,9 +71,88 @@ spec:
             value: $(params.repo_url)
           - name: REVISION
             value: $(params.revision)
-      - name: buildah-pvc
+      - name: lint-and-test
         runAfter:
           - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source
+        taskSpec:
+          workspaces:
+            - name: source
+          volumes:
+            - name: env-file-volume
+              secret:
+                secretName: integration-tests-env-file
+            - name: examples-volume
+              configMap:
+                name: integration-tests-reports
+          steps:
+            - name: lint-test
+              env:
+                - name: PIP_ROOT_USER_ACTION
+                  value: "ignore"
+                - name: AGENT_MORPHEUS_TRACING_ENABLED
+                  value: "false"
+              image: docker.io/condaforge/miniforge3:latest
+              workingDir: $(workspaces.source.path)
+              volumeMounts:
+                - name: env-file-volume
+                  mountPath: $(workspaces.source.path)/.env
+                  subPath: .env
+                - name: examples-volume
+                  mountPath: $(workspaces.source.path)/examples
+              script: |
+                #!/bin/bash
+                
+                set -eo pipefail 
+
+                ENV_NAME="test-env"
+                CONDA_PKGS="make pylint pytest pytest-asyncio pytest-dotenv python-dotenv openpyxl ragas seaborn"
+                PIP_PKGS="langchain_nvidia_ai_endpoints==0.2.0"
+
+                print_banner() {
+                    echo
+                    echo "----------- ${1} -----------"
+                }
+
+                print_banner "CHECKING FOR .ENV FILE"
+                if [ -f .env ]; then
+                    echo ".env file successfully mounted."
+                else
+                    echo "ERROR: .env file not found!"
+                    exit 1
+                fi
+
+                print_banner "CHECKING FOR EXAMPLES DIR"
+                if [ -d "examples" ] && [ -n "$(ls -A examples)" ]; then
+                    echo "Examples directory successfully mounted."
+                else
+                    echo "ERROR: Examples directory not found or is empty!"
+                    exit 1
+                fi
+
+                print_banner "CREATING TEST ENV"
+                mamba env create --log-level error -q -y -f requirements.yaml -n "${ENV_NAME}"
+
+                print_banner "ACTIVATING CONDA ENV"
+                eval "$(mamba shell hook -s bash)"
+                mamba activate "${ENV_NAME}"
+
+                print_banner "INSTALLING TEST DEPENDENCIES"
+                mamba install --log-level error -q -y -c conda-forge ${CONDA_PKGS}
+                pip install -q ${PIP_PKGS}
+
+                print_banner "RUNNING LINTER"
+                make lint-pr
+
+                print_banner "RUNNING UNIT TESTS"
+                make test-unit
+                
+                print_banner "LINT AND TEST COMPLETE"
+      - name: buildah-pvc
+        runAfter:
+          - lint-and-test
         params:
           - name: IMAGE
             value: $(params.output-image)
@@ -117,7 +196,6 @@ spec:
 
           - name: buildah-temp-cache
             workspace: buildah-temp-cache
-
   workspaces:
   - name: source
     volumeClaimTemplate:


### PR DESCRIPTION
This PR introduces a `lint-and-test` stage to Tekton pipelines for both pull requests and push events. 
The new stage automatically runs linter, unit, and integration tests, ensuring all code is validated before the build.
Test failures will block the pipeline, while linter issues will only report warnings.