### PR TITLE
fix: resolve buildah-pvc failure on OCP 4.17+

### DIFF
--- a/.tekton/tasks/buildah-task.yaml
+++ b/.tekton/tasks/buildah-task.yaml
@@ -3,7 +3,8 @@ kind: Task
 metadata:
   name: buildah-pvc
   namespace: ruben-morpheus
-
+  annotations:
+    io.kubernetes.cri-o.Devices: /dev/fuse
 spec:
   description: |
     Buildah task builds source into a container image and
@@ -31,7 +32,7 @@ spec:
       type: string
     - default: overlay
       description: |
-        Set buildah storage driver to reflect the currrent cluster node's
+        Set buildah storage driver to reflect the current cluster node's
         settings.
       name: STORAGE_DRIVER
       type: string
@@ -145,7 +146,7 @@ spec:
       name: scripts-dir
   workspaces:
     - description: |
-        Container build context, like for instnace a application source code
+        Container build context, like for instance a application source code
         followed by a `Dockerfile`.
       name: source
     - description: |


### PR DESCRIPTION
The `buildah-pvc task` fails on OCP 4.17+ with the error when using the overlay storage driver

```text
2025-07-21T10:01:04.424250762Z Error: mounting new container: mounting build container "e9cb280f4e1db6ad07b32fc033219e3b278be3418c14b9690624757041a0df84": creating overlay mount to /var/lib/containers/storage/overlay/585d23217c1e9c46ae1c3febdca746cef91e64b90ecc75c4de....../lib/containers/storage/overlay/585d23217c1e9c46ae1c3febdca746cef91e64b90ecc75c4de8891c866487f00/work,volatile": using mount program /usr/bin/fuse-overlayfs: unknown argument ignored: lazytime
2025-07-21T10:01:04.424250762Z fuse: device not found, try 'modprobe fuse' first
2025-07-21T10:01:04.424250762Z fuse-overlayfs: cannot mount: No such file or directory
2025-07-21T10:01:04.424250762Z : exit status 1
```
Instead of creating a custom SCC or using privileged mode this commit annotates the Task with `io.kubernetes.cri-o.Devices: "/dev/fuse"`
This securely provides the required device directly to the pod without granting excessive privileged permissions
