### PR TITLE
ci: trigger PipelineRun on non-draft PRs only

### DIFF
--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -4,14 +4,12 @@ kind: PipelineRun
 metadata:
   name: vulnerability-analysis-on-pr
   annotations:
-    # The event we are targeting as seen from the webhook payload
-    # this can be an array too, i.e: [pull_request, push]
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
-
-    # The branch or tag we are targeting (ie: main, refs/tags/*)
-    pipelinesascode.tekton.dev/on-target-branch: "[main, rh-aiq-main]"
-    # Paths that trigger the pipeline on change
-    pipelinesascode.tekton.dev/on-path-change: "[src/**, metrics_lib/**, pyproject.toml, Dockerfile, .dockerignore]"
+    # Trigger on non-draft PRs to target branches when specific paths are changed.
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      !body.pull_request.draft &&
+      (target_branch == "main" || target_branch == "rh-aiq-main") &&
+      ("src/**".pathChanged() || "metrics_lib/**".pathChanged() || "pyproject.toml".pathChanged() || "uv.lock".pathChanged() || "Dockerfile".pathChanged() || ".dockerignore".pathChanged())
     # Fetch the git-clone task from hub, we are able to reference later on it
     # with taskRef and it will automatically be embedded into our pipeline.
     pipelinesascode.tekton.dev/task: "git-clone"


### PR DESCRIPTION
Trigger on non-draft PRs only
Switched to `on-cel-expression` because of the priority. [PAC reference](https://pipelinesascode.com/docs/guide/matchingevents/#advanced-event-matching-using-cel)