### PR TITLE
fix: configure VDB persistent cache directory

### DIFF
--- a/src/vuln_analysis/functions/cve_generate_vdbs.py
+++ b/src/vuln_analysis/functions/cve_generate_vdbs.py
@@ -132,7 +132,10 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
         if source_infos:
 
             # Use DocumentEmbedding class with embedding=None for its utility functions
-            embedder = DocumentEmbedding(embedding=None)
+            embedder = DocumentEmbedding(embedding=None,
+                                         vdb_directory=config.base_vdb_dir,
+                                         git_directory=config.base_git_dir,
+                                         pickle_cache_directory=config.base_pickle_dir)
 
             # Determine code index path for either loading from cache or creating new index
             # Need to add support for configurable base path


### PR DESCRIPTION
The code indexer was creating a new `DocumentEmbedding` instance with default relative paths, ignoring the cache directories specified in the configuration. 

This change ensures the correct paths from the config are passed during initialization, forcing the indexer to use the intended cache directory.