### PR TITLE
chore: point cache directories to persistent volume mount path

### DIFF
--- a/kustomize/base/exploit-iq-config.yml
+++ b/kustomize/base/exploit-iq-config.yml
@@ -29,10 +29,10 @@ functions:
     _type: cve_generate_vdbs
     agent_name: cve_agent_executor  # Used to determine which tools are enabled
     embedder_name: nim_embedder
-    base_git_dir: .cache/am_cache/git
-    base_vdb_dir: .cache/am_cache/vdb
-    base_code_index_dir: .cache/am_cache/code_index
-    base_pickle_dir: .cache/am_cache/pickle
+    base_git_dir: ${EXPLOIT_IQ_DATA_DIR:-/exploit-iq-data/}git
+    base_vdb_dir: ${EXPLOIT_IQ_DATA_DIR:-/exploit-iq-data/}vdb
+    base_code_index_dir: ${EXPLOIT_IQ_DATA_DIR:-/exploit-iq-data/}code_index
+    base_pickle_dir: ${EXPLOIT_IQ_DATA_DIR:-/exploit-iq-data/}pickle
     ignore_code_embedding: true
   cve_fetch_intel:
     _type: cve_fetch_intel

--- a/kustomize/base/exploit_iq_service.yaml
+++ b/kustomize/base/exploit_iq_service.yaml
@@ -105,6 +105,8 @@ spec:
               value: http://nginx-cache:8080/ubuntu
             - name: ENABLE_EXTENDED_JS_PARSERS
               value: "True"
+            - name: EXPLOIT_IQ_DATA_DIR
+              value: /exploit-iq-data
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -113,7 +115,7 @@ spec:
             - name: config
               mountPath: /configs
             - name: cache
-              mountPath: /morpheus-data
+              mountPath: /exploit-iq-data
             - name: ca-bundle
               mountPath: /app/certs
               readOnly: true


### PR DESCRIPTION
This change updates the base Kustomize configuration to use the `/morpheus-data` persistent volume for all caching directories.