### PR TITLE
fix: pin litellm and enforce lockfile to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY ./ /workspace
 RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \
     export SETUPTOOLS_SCM_PRETEND_VERSION=${VULN_ANALYSIS_VERSION} && \
     uv venv --python ${PYTHON_VERSION} /workspace/.venv && \
-    uv sync --prerelease=allow
+    uv sync
 
 # Activate the environment (make it default for subsequent commands)
 RUN echo "source /workspace/.venv/bin/activate" >> ~/.bashrc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
   "tantivy==0.22.2",
   "tree-sitter==0.21.3",
   "tree-sitter-languages==1.10.2",
-  "univers==30.12"
+  "univers==30.12",
+  "litellm<=1.75.8",
 ]
 requires-python = ">=3.11,<3.13"
 description = "NVIDIA AI Blueprint: Vulnerability Analysis for Container Security"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -5287,6 +5287,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "google-search-results" },
     { name = "json5" },
+    { name = "litellm" },
     { name = "nbformat" },
     { name = "nemollm" },
     { name = "nvidia-nat", extra = ["langchain", "profiling", "telemetry"] },
@@ -5324,12 +5325,13 @@ requires-dist = [
     { name = "aiohttp-client-cache", specifier = "==0.11" },
     { name = "aioresponses", specifier = "==0.7.6" },
     { name = "brotli" },
-    { name = "cvss" },
+    { name = "cvss", specifier = "==3.6" },
     { name = "esprima" },
     { name = "faiss-cpu", specifier = "==1.9.0" },
     { name = "gitpython" },
     { name = "google-search-results", specifier = "==2.4" },
     { name = "json5" },
+    { name = "litellm", specifier = "<=1.75.8" },
     { name = "nbformat" },
     { name = "nemollm" },
     { name = "nvidia-nat", extras = ["langchain", "profiling", "telemetry"], specifier = ">=1.2.0rc8,<1.3.0" },


### PR DESCRIPTION
A recent update to the transitive dependency `litellm` caused a resolution conflict, forcing `uv` to select an old version of `tokenizers` (0.13.3). This version lacks pre-built wheels for Python 3.12, which resulted in build failures due to a missing Rust compiler.

This was made worse by the `uv sync --prerelease=allow` command in the Dockerfile, which caused the lockfile to be skipped during builds.

This commit resolves the issue by:
1. Pinning `litellm` to a known-good version (`<=1.75.8`) in `pyproject.toml`.
2. Regenerating `uv.lock` to reflect this stable dependency tree.
3. Removing the `--prerelease=allow` flag from the `Dockerfile` to ensure `uv sync` strictly adheres to the `uv.lock` file.


Error logs

```text
2025-09-16T13:44:02.001625205Z Using CPython 3.12.11
2025-09-16T13:44:02.001625205Z Creating virtual environment at: .venv
2025-09-16T13:44:03.202346678Z Ignoring existing lockfile due to change in pre-release mode: `if-necessary-or-explicit` vs. `allow`

help: `tokenizers` (v0.13.3) was included because `vuln-analysis` depends on
2025-09-16T13:44:28.463546682Z `nvidia-nat[telemetry]` (v1.2.1) which depends on `nvidia-nat-ragaai` (v1.2.1) which depends on `ragaai-catalyst` (v2.2.6b7) which depends on `litellm` (v1.77.1) which depends on `tokenizers`
```