### PR TITLE
fix: remove runAsGroup override in exploit-iq container

### DIFF
--- a/kustomize/base/exploit_iq_service.yaml
+++ b/kustomize/base/exploit_iq_service.yaml
@@ -61,7 +61,6 @@ spec:
 
           securityContext:
             runAsUser: 1001
-            runAsGroup: 1001
           ports:
             - name: http
               protocol: TCP


### PR DESCRIPTION
Removes the `runAsGroup: 1001` override from the exploit-iq container's securityContext that was causing pod crashes.

The exploit-iq container was experiencing a fatal error on startup:
```
ModuleNotFoundError: No module named 'encodings'
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
```

The `runAsGroup: 1001` setting in the deployment's securityContext was overriding the user's primary group, preventing access to the uv-managed Python installation at `/root/.local/share/uv/python/`.