### PR TITLE
fix: move SERPAPI_API_KEY to secret reference

### DIFF
--- a/kustomize/base/exploit_iq_service.yaml
+++ b/kustomize/base/exploit_iq_service.yaml
@@ -75,7 +75,10 @@ spec:
               cpu: "1000m"
           env:
             - name: SERPAPI_API_KEY
-              value: EXPLOIT_IQ
+              valueFrom:
+                secretKeyRef:
+                  key: serpapi_api_key
+                  name: exploit-iq-secret
             - name: NVIDIA_API_KEY
               value: EXPLOIT_IQ
             - name: OPENAI_API_KEY


### PR DESCRIPTION
Replaces the hardcoded `SERPAPI_API_KEY` placeholder value with a reference to a Kubernetes secret