### PR TITLE
feat: add custom Git SSL CA certificate support

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -182,6 +182,56 @@ EOF
 export CALLBACK_URL="https://exploit-iq-client.$(oc project -q).svc:8443"
 find . -type f -name 'exploit-iq-config.yml' -exec sed -i "s|CALLBACK_URL_PLACEHOLDER|$CALLBACK_URL|g" {} +
 ```
+
+### Configuring Git SSL Certificate Authority for Custom CAs
+
+If your Git server uses a certificate that is signed by a custom Certificate Authority (CA), you must provide the CA certificate bundle to enable ExploitIQ to verify the Git server identity.
+
+> [!IMPORTANT]
+> If you need to access Red Hat internal Git repositories such as `gitlab.cee.redhat.com`, you must complete this procedure.
+
+#### Procedure
+
+1. Create the certificate directory:
+
+```shell
+mkdir -p kustomize/base/ca-certs
+```
+
+2. Obtain your CA certificates.
+
+For Red Hat internal Git repositories:
+
+```shell
+# Download the Red Hat Root CA
+curl -o kustomize/base/ca-certs/internal-root-ca.pem \
+  https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem
+
+# Download the Red Hat internal Intermediate CA
+curl -o kustomize/base/ca-certs/rhcs-intermediate-ca.crt \
+  https://certs.corp.redhat.com/chains/rhcs-ca-chain-2022-self-signed.crt
+```
+
+For other custom CAs:
+
+```shell
+# Copy your custom CA certificate files to the directory
+cp /path/to/your-custom-ca.pem kustomize/base/ca-certs/
+```
+
+3. Create the CA bundle by concatenating all certificates:
+
+```shell
+cat kustomize/base/ca-certs/*.{pem,crt} > kustomize/base/ca-certs/ca-bundle.crt
+```
+
+4. Verify that the bundle contains your certificates:
+
+```shell
+openssl crl2pkcs7 -nocrl -certfile kustomize/base/ca-certs/ca-bundle.crt | \
+  openssl pkcs7 -print_certs -noout
+```
+
 >[!IMPORTANT]
 You should only run one of the steps 9,10 or 11, depending on if you want to run the service with a self hosted LLM, self hosted LLM with MLOps or Nvidia remote NIM.
 9. To deploy `ExploitIQ` with a self-hosted LLM , run:

--- a/kustomize/base/.gitignore
+++ b/kustomize/base/.gitignore
@@ -1,0 +1,8 @@
+# Certificate files - contains sensitive internal CA certificates
+ca-certs/*.pem
+ca-certs/*.crt
+ca-certs/ca-bundle.crt
+
+# Keep the directory structure
+!ca-certs/.gitkeep
+!ca-certs/README.md

--- a/kustomize/base/ca-certs/README.md
+++ b/kustomize/base/ca-certs/README.md
@@ -1,0 +1,22 @@
+# Git SSL CA Certificates Directory
+
+This directory contains Certificate Authority (CA) certificates for Git SSL verification.
+
+## Purpose
+
+If your Git server uses certificates signed by a custom CA, place the CA certificate files in this directory. The deployment process creates a ConfigMap from these certificates and mounts it to the ExploitIQ pod.
+
+## Instructions
+
+Refer to the [Configuring Git SSL Certificate Authority for Custom CAs](../../README.md#configuring-git-ssl-certificate-authority-for-custom-cas) section in the main deployment documentation for detailed instructions on downloading and configuring CA certificates.
+
+## Red Hat Internal Access
+
+For Red Hat internal Git repositories (gitlab.cee.redhat.com), download:
+
+- Root CA: <https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem>
+- Intermediate CA: <https://certs.corp.redhat.com/chains/rhcs-ca-chain-2022-self-signed.crt>
+
+## Security
+
+**Do not commit certificate files to version control.** These files are gitignored to prevent accidental exposure of internal CA certificates in public repositories.

--- a/kustomize/base/exploit_iq_service.yaml
+++ b/kustomize/base/exploit_iq_service.yaml
@@ -138,6 +138,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: GIT_SSL_CAINFO
+              value: /app/git-ca-bundle/ca-bundle.crt
           volumeMounts:
             - name: config
               mountPath: /configs
@@ -147,6 +149,9 @@ spec:
               mountPath: /exploit-iq-package-cache
             - name: ca-bundle
               mountPath: /app/certs
+              readOnly: true
+            - name: git-ca-bundle
+              mountPath: /app/git-ca-bundle
               readOnly: true
       volumes:
         - name: config
@@ -161,6 +166,10 @@ spec:
         - name: ca-bundle
           configMap:
             name: openshift-service-ca.crt
+        - name: git-ca-bundle
+          configMap:
+            name: git-ca-bundle
+            optional: true
 ---
 apiVersion: v1
 kind: Service

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -70,6 +70,12 @@ configMapGenerator:
       - excludes.json
       - includes.json
 
+  - name: git-ca-bundle
+    files:
+      - ca-certs/ca-bundle.crt
+    options:
+      disableNameSuffixHash: true
+
 patches:
   - path: ips-patch.json
               


### PR DESCRIPTION
Enable Git operations with custom Certificate Authorities by configuring `GIT_SSL_CAINFO` environment variable and mounting CA bundle ConfigMap.