### PR TITLE
APPENG-4536: Add multi-prompt factory with LLM catalog and language rendering

### DIFF
--- a/src/vuln_analysis/utils/multi_prompt_factory.py
+++ b/src/vuln_analysis/utils/multi_prompt_factory.py
@@ -43,7 +43,6 @@ language placeholders that remain after templating has completed will be deleted
 This string will be rendered by the Jinja2 template engine, the template engine will replace the placeholders with the actual values specified in the language adjustments dictionary and 
 """
 
-
 class PromptId(StrEnum):
     CHECKLIST_MAIN = "checklist_main"
     CHECKLIST_SUB = "checklist_sub"

--- a/src/vuln_analysis/utils/multi_prompt_factory.py
+++ b/src/vuln_analysis/utils/multi_prompt_factory.py
@@ -1,0 +1,218 @@
+from enum import StrEnum
+from jinja2 import Template
+
+"""
+multi_prompt_generator.py
+
+This module provides utilities for managing and rendering multiple prompt templates,
+with support for language-specific adjustments and extensible prompt cataloging. It
+defines enumerations for prompt IDs, language adjustments, and supported languages.
+It also contains logic for resolving prompt templates with possible language adaptations,
+primarily used in vulnerability analysis scenarios where prompts may need to be customized
+based on the programming language or other criteria.
+
+Key components:
+- PromptId: Enum to identify different prompt templates.
+- LanguageAdjustmentsKey: Enum of keys that can be replaced within templates by language-specific values.
+- Language: Supported programming languages.
+- PromptCatalogError: Custom error raised when a prompt lookup fails.
+- _CATALOG: Main dictionary structure holding prompt templates, data, and per-language adjustments.
+
+Example usage:
+Modules using this utility can render prompts with proper language-specific adjustments,
+fetch prompts safely by ID, and handle missing catalog entries gracefully.
+
+Users of this module shall call to function get_prompt with ther require parameters to get the prompt string
+See main function for example usage.
+
+Below is informatoin how to maintain (add/edit) the prmopt catalog
+_CATALOG is the prompt catalog dictionary,
+ The first level key is the prompt id which shall be one of the PromptId enum values.
+ The second level key is the llm family key, e.g: "llama".
+  Within the llm family key, the data dictionary contains prompts and language adjustments.
+  The llm family key can have multiple versions, e.g: "3.1", for each version, the data dictionary contains prompts and language adjustments in similiar structure.
+
+The prompts within the data dictionary are a list of strings, the get_prompt function will join the list of strings into a single string, 
+and then it will be rendered by the Jinja2 template engine with the kwargs provided in the get_prompt function call (named **ctx)
+Besides the general template parameter provided by **ctx, the language adjustments dictionary will be also provided to the template engine.
+The language adjustments dictionary (named language) defined within the llm (familiy/version) will contain the languages adjustments.
+Note: In the prompt body, the language placeholders shall be defined as {{ LANG_ADJUSTMENT_1 }}, {{ LANG_ADJUSTMENT_2 }}.
+Having multiple language placholders make the adjusments more flexible, allow one language to have more adjustments than other language.
+language placeholders that remain after templating has completed will be deleted from the prompt.
+
+This string will be rendered by the Jinja2 template engine, the template engine will replace the placeholders with the actual values specified in the language adjustments dictionary and 
+"""
+
+
+class PromptId(StrEnum):
+    CHECKLIST_MAIN = "checklist_main"
+    CHECKLIST_SUB = "checklist_sub"
+
+# These are keys to be used within each language block, which allow to be replaced with the actual adjustment value.
+# In case prompt define a key and the corresponding block of the given language has not been specified with, the key will be cleared from the prompt.
+class LanguageAdjustmentsKey(StrEnum):
+    LANG_ADJUSTMENT_1 = "LANG_ADJUSTMENT_1"
+    LANG_ADJUSTMENT_2 = "LANG_ADJUSTMENT_2"
+    LANG_ADJUSTMENT_3 = "LANG_ADJUSTMENT_3"
+
+class Language(StrEnum):
+    JAVA = "Java"
+    PYTHON = "Python"
+    JAVASCRIPT = "JavaScript"
+    C = "C"
+    GO = "Go"
+
+
+class PromptCatalogError(KeyError):
+    """Raised when a prompt cannot be resolved from the catalog."""
+
+_CATALOG: dict[PromptId, dict] = {
+    PromptId.CHECKLIST_MAIN: {
+        # Broad Family
+        "llama": {
+            # Data for Broad family
+            "data": {
+                "prompts": [
+                    "First paragraph of llama prompt"
+                    "second line of first paragraph of llama prompt",
+                    "Second prompt line"
+                ],
+                # Language adjusments
+                "language": {
+                    "Java": {
+                        # Thess keys be refer from the prompt template
+                        LanguageAdjustmentsKey.LANG_ADJUSTMENT_1.value: "Java adjustment 1 for llama",
+                        LanguageAdjustmentsKey.LANG_ADJUSTMENT_2.value: "Java adjustment 2 for llama",
+                    },
+                    Language.GO.value: {
+                        LanguageAdjustmentsKey.LANG_ADJUSTMENT_1.value: "Go adjustment 1 for llama",
+                        LanguageAdjustmentsKey.LANG_ADJUSTMENT_2.value: "Go adjustment 2 for llama",
+                    }
+                }
+            },
+            # Using sub-comp, to allow generic strucure that allow recursive search..
+            "version": {
+                "3.1": {
+                    # Data for llama-3.1
+                    "data": {
+                        "prompts": [
+                            "First paragraph of llama 3.1 prompt language adjuments 1 {{ LANG_ADJUSTMENT_1 }} after language adjustment key\n"
+                            "second line of first paragraph of llama prompt language adjuments 2 {{ LANG_ADJUSTMENT_2 }} after language adjustment key\n",
+                            "third line of first paragraph of llama prompt  ",
+                            "Second prompt line {{ xxx }} {{ yyy }} "
+                        ],
+                        # Language adjusments
+                        "language": {
+                            Language.JAVA.value: {
+                                LanguageAdjustmentsKey.LANG_ADJUSTMENT_1.value: "Java adjustment 1 for llama 3.1",
+                                LanguageAdjustmentsKey.LANG_ADJUSTMENT_2.value: "Java adjustment 2 for llama 3.1"
+                            },
+                            Language.GO.value: {
+                                LanguageAdjustmentsKey.LANG_ADJUSTMENT_1.value: "Go adjustment 1 for llama 3.1",
+                                LanguageAdjustmentsKey.LANG_ADJUSTMENT_2.value: "Go adjustment 2 for llama 3.1"
+                            }                            
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+def get_prompt(prompt_id: PromptId, llm: list[str] | None = None, language: Language | None = None, **ctx: str) -> str:
+    # INSERT_YOUR_CODE
+    """
+    Retrieve a prompt string from the catalog based on the given parameters.
+
+    Args:
+        prompt_id (PromptId): The identifier for the prompt.
+        llm (list[str] | None): A list containing the LLM family key and optionally a version key.
+        language (Language | None): The programming language context for possible prompt adjustments.
+        **ctx (str): Additional context variables for template substitution.
+
+    Returns:
+        str: The final filled prompt string ready for LLM use.
+
+    Raises:
+        PromptCatalogError: If any of the supplied parameters are invalid, or the prompt entry is missing.
+    """
+    if prompt_id not in _CATALOG:
+        raise PromptCatalogError(f"Prompt id {prompt_id!r} not found in catalog")
+
+    selected_prompt_root: dict = _CATALOG[prompt_id]
+
+    if llm is None:
+        raise PromptCatalogError("llm cannot be None")
+
+    if not llm:
+        raise PromptCatalogError("llm must contain at least one key")
+
+    llm_key = llm[0]
+    if llm_key not in selected_prompt_root:
+        raise PromptCatalogError(
+            f"LLM key {llm_key!r} not found in catalog entry for {prompt_id!r}"
+        )
+    selected_prompt_root = selected_prompt_root[llm_key]
+
+    if len(llm) > 1:
+        version_key = llm[1]
+        versions = selected_prompt_root.get("version")
+        if versions is None or version_key not in versions:
+            raise PromptCatalogError(
+                f"Version key {version_key!r} not found under 'version' for LLM {llm_key!r}"
+            )
+        selected_prompt_root = versions[version_key]
+
+    try:
+        prompts = selected_prompt_root["data"]["prompts"]
+    except KeyError as exc:
+        raise PromptCatalogError(
+            f"No prompts found under resolved catalog node for {prompt_id!r}"
+        ) from exc
+
+    if not isinstance(prompts, list):
+        raise PromptCatalogError(
+            f"Expected prompts to be a list for {prompt_id!r}, got {type(prompts).__name__}"
+        )
+
+    prompt = " ".join(prompts)
+    template = Template(prompt)
+
+    if language is not None:
+        if not isinstance(language, Language):
+            try:
+                language = Language(language)
+            except ValueError as exc:
+                supported = [member.value for member in Language]
+                raise PromptCatalogError(
+                    f"Unsupported language {language!r}; supported values: {supported}"
+                ) from exc
+
+        language_blocks = selected_prompt_root.get("data", {}).get("language")
+        if language_blocks is None or language.value not in language_blocks:
+            print(
+                f"Language adjustments are not defined for given language {language.value!r}"
+            )
+        else:
+            language_adjusments_dict = language_blocks[language.value]
+            # print(f"language_adjusments_dict: {language_adjusments_dict}")
+            # print(f"prompt before rendering: {prompt}")
+            rendered_prompt = template.render(**language_adjusments_dict, **ctx)
+            # print(rendered_prompt)
+            return rendered_prompt
+
+    return prompt
+
+def main() -> None:
+    # print(_CATALOG)
+    print("=== Prompt for llama 3.1 for Java")
+    print(get_prompt(PromptId.CHECKLIST_MAIN, llm=["llama", "3.1"], language=Language.JAVA, xxx="xxx1", yyy="yyy1"))
+    print("=== Prompt for llama for Java")
+    print(get_prompt(PromptId.CHECKLIST_MAIN, llm=["llama"], language=Language.JAVA, xxx="xxx1", yyy="yyy1"))    
+    print("=== Prompt for llama 3.1 for Go")
+    print(get_prompt(PromptId.CHECKLIST_MAIN, llm=["llama", "3.1"], language=Language.GO, xxx="xxx1", yyy="yyy1"))    
+    # print(get_prompt(PromptId.CHECKLIST_MAIN, llm=["llama"], language=Language.JAVA))    
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
APPENG-4536: Add multi-prompt factory with LLM catalog and language rendering

Introduce a catalog-driven prompt resolver so vulnerability-analysis prompts can be selected and customized by prompt type, LLM family/version, and programming language without scattering template strings across callers.