### PR TITLE
Remove unreachable code across Java analysis files and fix count_of_dots bug in function_name_locator

### DIFF
--- a/src/exploit_iq_commons/utils/dep_tree.py
+++ b/src/exploit_iq_commons/utils/dep_tree.py
@@ -326,13 +326,10 @@ class CCppDependencyTreeBuilder(DependencyTreeBuilder):
         rel_path = Path(os.path.relpath(os.path.dirname(path), self.root_dir))
         parts = rel_path.parts
         if self.RPM_LIBS_DIR in parts:
-            try:
-                idx = parts.index(self.RPM_LIBS_DIR)
-                if idx + 1 < len(parts):
-                    module = parts[idx + 1]
-                    return module
-            except ValueError:
-                pass
+            idx = parts.index(self.RPM_LIBS_DIR)
+            if idx + 1 < len(parts):
+                module = parts[idx + 1]
+                return module
         module = self.prj_name or "ROOT"
         return module
 
@@ -482,13 +479,8 @@ class CCppDependencyTreeBuilder(DependencyTreeBuilder):
             mod = self.module_from_path(candidate)
             if mod != self.C_STANDARD_LIB:
                 return mod
-        # Fallback to glibc
-        for candidate in candidates:
-            mod = self.module_from_path(candidate)
-            if mod == self.C_STANDARD_LIB:
-                return self.C_STANDARD_LIB
-        # Fallback to first
-        return self.module_from_path(candidates[0])
+        # All candidates are glibc
+        return self.C_STANDARD_LIB
 
     # Build a sort of "upside down" tree - a dict containing mapping of each
     # package to a list of all consuming packages
@@ -788,7 +780,6 @@ class GoDependencyTreeBuilder(DependencyTreeBuilder):
         root_package_name = self._get_parent(lines[0])
         tree = dict()
         for line in lines:
-            line.split(" ")
             parent = self.extract_package_name(self._get_parent(line))
             son = self.extract_package_name(self._get_son(line))
             if tree.get(son, None) is None:

--- a/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
+++ b/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
@@ -756,20 +756,6 @@ class JavaChainOfCallsRetriever(ChainOfCallsRetrieverBase):
 
         return class_name, method_name, package_name
 
-    def __get_parents(self, importing_docs: list[Document], prefix_of_3rd_parties_libs: str) -> set[str]:
-        pkg_names = {
-            names[0]
-            for doc in importing_docs
-            if doc.metadata['source'].startswith(prefix_of_3rd_parties_libs)
-            for names in [self.language_parser.get_package_names(doc)]
-            if names
-        }
-
-        # 2) Keep only k's where the package name appears in them (substring logic preserved)
-        parents = {k for k in self.tree_dict if any(pkg in k for pkg in pkg_names)}
-
-        return parents
-
     def __determine_doc_package_name(self, target_function_doc, ctx: _JavaSearchCtx):
         """
         Determine the logical package/dependency identifier for a given document.
@@ -871,12 +857,9 @@ class JavaChainOfCallsRetriever(ChainOfCallsRetrieverBase):
         if (
                 target_simple not in src
                 and (not target_qual or target_qual not in src)
-                and f"new {target_simple}" not in src
-                and f"::{target_simple}" not in src
                 and not (
                 "::new" in src and (
                 (_looks_like_type_name(target_simple)) or
-                (target_qual and target_qual in src) or
                 (target_qual and target_qual.split(".")[-1] in src)
         )
         )

--- a/src/exploit_iq_commons/utils/java_segmenters_with_methods.py
+++ b/src/exploit_iq_commons/utils/java_segmenters_with_methods.py
@@ -351,8 +351,7 @@ class JavaSegmenterWithMethods(JavaSegmenter):
                 if ident == "extends":
                     saw_extends = True
                 elif saw_extends:
-                    # Allow qualified form: `extends junit.framework.TestCase`
-                    if ident.endswith("TestCase") and ident.rsplit(".", 1)[-1] == "TestCase":
+                    if ident == "TestCase":
                         return True
                     saw_extends = False
 
@@ -1050,7 +1049,7 @@ def _match_balanced_angles(source: str, open_angle_index: int) -> int:
             continue
 
         # Skip over literals so '<' or '>' inside them don't affect nesting.
-        if i < length and (source.startswith('"""', i) or source[i] in ('"', "'")):
+        if source.startswith('"""', i) or source[i] in ('"', "'"):
             i = _skip_java_string_like(source, i)
             continue
 
@@ -1117,7 +1116,7 @@ def _match_balanced_parens(source: str, open_paren_index: int) -> int:
             continue
 
         # Skip over literals so any '(' or ')' inside them don't affect nesting.
-        if i < length and (source.startswith('"""', i) or source[i] in ('"', "'")):
+        if source.startswith('"""', i) or source[i] in ('"', "'"):
             i = _skip_java_string_like(source, i)
             continue
 
@@ -1189,7 +1188,7 @@ def _match_balanced_braces(source: str, open_brace_index: int) -> int:
             continue
 
         # Skip over literals so braces inside them don't affect nesting.
-        if i < length and (source.startswith('"""', i) or source[i] in ('"', "'")):
+        if source.startswith('"""', i) or source[i] in ('"', "'"):
             i = _skip_java_string_like(source, i)
             continue
 
@@ -1354,15 +1353,6 @@ def _skip_throws_clause(src: str, i: int) -> int:
             break
         i += 1
     return _skip_ws_comments(src, i)
-
-# ----------------------- type discovery for constructor filter ----------------
-
-class _TypeRegion:
-    __slots__ = ("name", "start", "end")  # '{' index .. matching '}' index
-    def __init__(self, name: str, start: int, end: int) -> None:
-        self.name = name
-        self.start = start
-        self.end = end
 
 # --------------------------------- lambdas ------------------------------------
 
@@ -1886,8 +1876,6 @@ def _extract_methods_anywhere(
             break
 
         i = _skip_ws_and_comments(s, i, line_end)
-        while i < line_end and s[i].isspace():
-            i += 1
         return i >= line_end
 
     def _skip_annotation_only_lines(s: str, i: int, lim: int) -> int:
@@ -2961,8 +2949,6 @@ def extract_inner_classes(src: str) -> list[str]:
             break
 
         i = _skip_ws_comments(s, i)
-        while i < line_end and s[i].isspace():
-            i += 1
         return i >= line_end
 
     def _consume_annotations(i: int) -> int:

--- a/src/exploit_iq_commons/utils/java_utils.py
+++ b/src/exploit_iq_commons/utils/java_utils.py
@@ -338,7 +338,6 @@ def collect_fields_from_types(
         simple = base.split(".")[-1]
         if simple.lower() in JAVA_METHOD_PRIM_TYPES: return False
         if simple in WRAPS: return False
-        if base.startswith("java.lang.") and simple in WRAPS: return False
         return True
 
     def parse_field_header(header: str) -> List[Tuple[str, str]]:

--- a/src/vuln_analysis/tools/transitive_code_search.py
+++ b/src/vuln_analysis/tools/transitive_code_search.py
@@ -492,9 +492,7 @@ async def library_version_finder(config: FunctionLibraryVersionFinderToolConfig,
             # Java GAV format: "groupId:artifactId:version"
             package_lower = package.lower()
             parts = package_lower.split(":")
-            if (search_term in package_lower or
-                    any(search_term == part for part in parts) or
-                    any(search_term in part for part in parts)):
+            if search_term in package_lower:
                 matching_packages.append(package)
 
         if not matching_packages:

--- a/src/vuln_analysis/utils/function_name_locator.py
+++ b/src/vuln_analysis/utils/function_name_locator.py
@@ -145,7 +145,7 @@ class FunctionNameLocator:
             List of function names in format 'package,function_name' that match the search term,
             or error message with package suggestions if package is not found
         """
-        count_of_dots = input_function.count('.')
+        count_of_dots = min(input_function.count('.'), 2)
 
         list_of_matching_combinations = set()
         for doc in package_docs:

--- a/src/vuln_analysis/utils/function_name_locator.py
+++ b/src/vuln_analysis/utils/function_name_locator.py
@@ -145,10 +145,7 @@ class FunctionNameLocator:
             List of function names in format 'package,function_name' that match the search term,
             or error message with package suggestions if package is not found
         """
-        count_of_dots = 0
-        splitters = [splitter for splitter in ['.'] if splitter in input_function]
-        if splitters:
-            count_of_dots = len(splitters)
+        count_of_dots = input_function.count('.')
 
         list_of_matching_combinations = set()
         for doc in package_docs:


### PR DESCRIPTION
dep_tree.py:
  - Remove unreachable `except ValueError` around `parts.index(RPM_LIBS_DIR)` — the enclosing `if RPM_LIBS_DIR in parts` guarantees the index call succeeds.
  - Replace dead glibc fallback loop + unreachable final return with direct `return self.C_STANDARD_LIB` — if the non-glibc loop exhausts without returning, all candidates must be glibc, so the glibc loop's first iteration always returns, making the final `return` unreachable.
  - Remove no-op `line.split(" ")` whose result was never assigned.

  java_chain_of_calls_retriever.py:
  - Remove redundant `f"new {target_simple}" not in src` and `f"::{target_simple}" not in src` from early-exit guard — the preceding `target_simple not in src` already guarantees these substrings are absent.
  - Remove always-False `(target_qual and target_qual in src)` branch — the outer condition already established `target_qual not in src`.
  - Remove dead `__get_parents` method — never called anywhere in the project.

  java_utils.py:
  - Remove unreachable `if base.startswith("java.lang.") and simple in WRAPS` — the preceding `if simple in WRAPS: return False` already handles all cases where `simple in WRAPS`.

  function_name_locator.py:
  - Fix broken `count_of_dots` calculation. Old code used a list comprehension over a single-element list `['.']`, producing only 0 or 1, making the `count_of_dots == 2` branch permanently unreachable. Replaced with `input_function.count('.')`.

  transitive_code_search.py:
  - Simplify 3-way `or` condition in library_version_finder to single `search_term in package_lower` — since `package_lower` is `":".join(parts)`, the substring check subsumes both `any(search_term == part ...)` and `any(search_term in part ...)`.

  java_segmenters_with_methods.py:
    ident.rsplit(".", 1)[-1] == "TestCase"` to `ident == "TestCase"` — `_is_ident_part` excludes '.', so ident never contains dots, making rsplit return [ident] itself; endswith + rsplit is equivalent to ==.
  - Remove 3 always-True `if i < length` guards inside `while i < length` loops — guaranteed by the enclosing loop condition.
  - Remove 2 dead `while ... isspace()` loops after `_skip_ws_and_comments` / `_skip_ws_comments` — both functions already consume all whitespace.
  - Remove dead module-level `_TypeRegion` class — shadowed by an identical local class defined inside `_extract_methods_anywhere`.