### PR TITLE
APPENG-5343: Fix LLM checklist tool_descriptions parsing

### DIFF
--- a/src/vuln_analysis/utils/checklist_prompt_generator.py
+++ b/src/vuln_analysis/utils/checklist_prompt_generator.py
@@ -31,7 +31,8 @@ logger = LoggingFactory.get_agent_logger(__name__)
 # Format MOD_FEW_SHOT with examples, preserving {tool_descriptions} for Jinja2 rendering
 # Use double braces for tool_descriptions to escape it during format()
 _MOD_FEW_SHOT_ESCAPED = MOD_FEW_SHOT.replace('{tool_descriptions}', '{{tool_descriptions}}')
-DEFAULT_CHECKLIST_PROMPT = _MOD_FEW_SHOT_ESCAPED.format(examples=get_mod_examples())
+INTERMEDIATE_CHECKLIST_PROMPT = _MOD_FEW_SHOT_ESCAPED.format(examples=get_mod_examples())
+DEFAULT_CHECKLIST_PROMPT = INTERMEDIATE_CHECKLIST_PROMPT.replace('{tool_descriptions}', '{{ tool_descriptions }}')
 
 cve_prompt2 = """Parse the following numbered checklist into a python list in the format ["x", "y", "z"], a comma separated list surrounded by square braces: {{template}}"""
 


### PR DESCRIPTION
The checklist generation LLM input contained the literal text '{tool_descriptions}' instead of templating it to the actual value.