### PR TITLE
APPENG-5393 update documentation and some  feedback improvment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ limitations under the License.
   - [Customizing the embedding model](#customizing-the-embedding-model)
     - [Steps to configure an alternate embedding provider](#steps-to-configure-an-alternate-embedding-provider)
   - [Customizing the Output](#customizing-the-output)
+- [RPM CVE Checker](#rpm-cve-checker)
 - [Limitations](#limitations)
 - [Troubleshooting](#troubleshooting)
   - [Git LFS issues](#git-lfs-issues)
@@ -771,6 +772,31 @@ The workflow can then be updated to use the new function:
 ```
 
 Additional output options will be added in the future.
+
+## RPM CVE Checker
+
+Determine if an RPM package is vulnerable to a specific CVE by examining source patches, changelogs, and build artifacts.
+
+**When to use:**
+- Investigating a specific CVE in a single RHEL or Fedora RPM package
+- Need source-level evidence (patches, changelogs) for vulnerability status
+- Targeted package analysis vs. container-wide scanning
+
+**Quick example:**
+```json
+{
+  "pipeline_mode": "package_checker",
+  "target_package": {
+    "name": "libarchive",
+    "version": "3.1.2",
+    "release": "14.el7_9.2",
+    "arch": "x86_64",
+    "cve_id": "CVE-2026-5121"
+  }
+}
+```
+
+For detailed usage, input/output formats, and verdict explanations, see [RPM CVE Checker Documentation](RPM-CVE-CHECKER.md).
 
 ## Limitations
 

--- a/RPM-CVE-CHECKER.md
+++ b/RPM-CVE-CHECKER.md
@@ -1,0 +1,246 @@
+# RPM CVE Checker
+
+Determine if an RPM package is vulnerable to a specific CVE by examining source patches, changelogs, and build artifacts.
+
+This mode provides targeted, single-package vulnerability analysis for RHEL and Fedora RPMs, producing detailed evidence-based verdicts.
+
+## Table of Contents
+
+- [Supported Distributions](#supported-distributions)
+- [How It Works](#how-it-works)
+- [Input Format](#input-format)
+- [Configuration](#configuration)
+- [Verdicts](#verdicts)
+- [Output Format](#output-format)
+- [Example](#example)
+- [Limitations](#limitations)
+
+## Supported Distributions
+
+| Distribution | L1 Source Analysis | L2 Compilation Check | L2 Hardening Check |
+|--------------|-------------------|---------------------|-------------------|
+| **RHEL** | Full | Full | Full |
+| **Fedora** | Full | Full | Not available |
+
+**RHEL** receives full analysis across both levels:
+- L1: Source analysis (spec files, changelogs, patches)
+- L2: Compilation check (detect disabled features) + hardening flag analysis (compiler protections)
+
+**Fedora** receives L1 + partial L2:
+- L1: Source analysis (spec files, changelogs, patches)
+- L2: Compilation check only (can detect if features like LDAP/OpenSSL are disabled via configure/makefiles)
+- No hardening flag analysis (different build system, no Brew build logs)
+
+## How It Works
+
+The checker performs a two-level investigation to determine vulnerability status:
+
+```mermaid
+flowchart TD
+    A["Input: CVE + RPM Package"] --> B["L1: Source Analysis"]
+    B --> C{"Backport found?"}
+    C -->|Yes| D["NOT_VULNERABLE"]
+    C -->|No| E["L2: Compilation Check"]
+    E --> F{"Code compiled?"}
+    F -->|No| D
+    F -->|Yes| G["L2: Hardening Check (RHEL only)"]
+    G --> H{"Hardening mitigates?"}
+    H -->|Yes| I["VULNERABLE_MITIGATED"]
+    H -->|No| J["VULNERABLE"]
+```
+
+### L1: Source Analysis
+
+Examines package source artifacts in three phases:
+
+1. **IDENTIFY** — Is this package affected by the CVE? (version range, architecture)
+2. **LOCATE** — Is the vulnerable code present in the source tree?
+3. **VERIFY** — Has a fix been applied? (backport patches, changelog entries, spec file references)
+
+### L2: Build Analysis
+
+When L1 finds no source-level fix:
+
+1. **Compilation Check** — Is the vulnerable code actually compiled into the binary? (feature flags, configure options)
+2. **Hardening Check** (RHEL only) — Do compiler flags mitigate the vulnerability? (`-fstack-protector`, RELRO, PIE, etc.)
+
+## Input Format
+
+Provide the target package and CVE via JSON input with `pipeline_mode: "package_checker"`.
+
+### RHEL Example
+
+```json
+{
+  "pipeline_mode": "package_checker",
+  "target_package": {
+    "name": "libarchive",
+    "version": "3.1.2",
+    "release": "14.el7_9.2",
+    "arch": "x86_64",
+    "cve_id": "CVE-2026-5121"
+  }
+}
+```
+
+### Fedora Example
+
+```json
+{
+  "pipeline_mode": "package_checker",
+  "target_package": {
+    "name": "openssl",
+    "version": "3.2.1",
+    "release": "1.fc40",
+    "arch": "x86_64",
+    "cve_id": "CVE-2024-2511"
+  }
+}
+```
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | RPM package name |
+| `version` | Package version |
+| `release` | Release string (e.g., `14.el7_9.2` for RHEL, `1.fc40` for Fedora) |
+| `arch` | Architecture (e.g., `x86_64`) |
+| `cve_id` | CVE identifier to investigate |
+
+## Configuration
+
+The RPM CVE Checker uses these configuration options in the workflow YAML:
+
+### Brew Profile (`rpm_user_type`)
+
+Controls which build system is used for fetching SRPMs and build logs:
+
+```yaml
+cve_source_acquisition:
+  _type: cve_source_acquisition
+  rpm_user_type: ${RPM_USER_TYPE:-internal}
+
+cve_package_code_agent:
+  _type: cve_package_code_agent
+  rpm_user_type: ${RPM_USER_TYPE:-internal}
+```
+
+| Profile | Hub | Build Logs | Use Case |
+|---------|-----|------------|----------|
+| `internal` | Red Hat Brew (`brewhub.engineering.redhat.com`) | Auto-fetched | RHEL packages (requires VPN) |
+| `external` | Fedora Koji (`koji.fedoraproject.org`) | Not fetched | Fedora packages (public access) |
+
+**Environment variable override:** Set `RPM_USER_TYPE=external` to override the config file value.
+
+### Cache Directories
+
+Configure where artifacts are stored:
+
+```yaml
+cve_source_acquisition:
+  base_rpm_dir: .cache/am_cache/rpms          # Shared SRPM cache
+  base_checker_dir: .cache/am_cache/checker   # Checker-specific artifacts
+
+cve_checker_segmentation:
+  base_checker_dir: .cache/am_cache/checker
+  base_code_index_dir: .cache/am_cache/code_index  # Tantivy search index
+```
+
+| Directory | Contents |
+|-----------|----------|
+| `base_rpm_dir` | Downloaded SRPMs (shared cache) |
+| `base_checker_dir` | Extracted sources, build logs, patches, reports |
+| `base_code_index_dir` | Tantivy full-text search index for source code |
+
+### Profile Details
+
+**Internal profile** (`internal-user-profile.yml`):
+- Connects to Red Hat Brew hub
+- Fetches build logs automatically (`build_log.auto_fetch: true`)
+- Enables L2 hardening check via build log analysis
+- Requires Red Hat VPN connection
+
+**External profile** (`external-user-profile.yml`):
+- Connects to Fedora Koji hub
+- Does not fetch build logs (`build_log.auto_fetch: false`)
+- L2 hardening check unavailable (no build log)
+- Public access, no authentication required
+
+For other configuration options (LLM models, output paths), see the main [Configuration file reference](README.md#configuration-file-reference).
+
+## Verdicts
+
+The checker produces one of three verdicts with a justification label explaining the reasoning:
+
+| Verdict | Justification Label | When |
+|---------|---------------------|------|
+| `NOT_VULNERABLE` | `code_not_present` | Package version outside affected range, architecture not applicable, or vulnerable code not compiled (feature disabled) |
+| `NOT_VULNERABLE` | `protected_by_mitigating_control` | Downstream backport patch applied, confirmed in changelog/spec/build log |
+| `VULNERABLE_MITIGATED` | `protected_by_compiler` | No source fix, but compiler hardening flags mitigate the exploit mechanism (RHEL only) |
+| `VULNERABLE` | `vulnerable` | Package is affected, no fix or relevant mitigation found |
+
+Each verdict includes a **confidence score** (0-100%) indicating the strength of evidence.
+
+## Output Format
+
+The checker produces a structured report with these sections:
+
+### Executive Summary
+One-paragraph assessment of vulnerability status with key findings.
+
+### Verdict and Justification
+- `justification_label`: The classification (see Verdicts table)
+- `confidence`: Percentage confidence in the verdict
+- Status: `TRUE` (vulnerable) or `FALSE` (not vulnerable)
+
+### Evidence Chain
+Bullet-point list of evidence supporting the verdict:
+- Patch files found/not found
+- Changelog mentions
+- Build log confirmations
+- Version comparisons
+
+### Extracted Facts
+Verbatim excerpts from package artifacts:
+- Spec `PatchN:` lines matching the CVE
+- `%changelog` entries mentioning the CVE
+- Build log lines showing patch application
+
+### Code Snippets
+When available, shows vulnerable code and fix code side-by-side.
+
+## Example
+
+**Input:** CVE-2026-5121 in `libarchive-3.1.2-14.el7_9.2`
+
+**Verdict:** `NOT_VULNERABLE` (`protected_by_mitigating_control`, 90% confidence)
+
+**Executive Summary:**
+The package is protected by a downstream patch that mitigates the vulnerability. The fix is carried as a separate %patch directive.
+
+**Evidence Chain:**
+- Downstream patch file `libarchive-3.3.3-Fix-CVE-2026-5121.patch` found and applied
+- Spec file contains: `Patch33: %{name}-3.3.3-Fix-CVE-2026-5121.patch`
+- Changelog contains: `Security fix for CVE-2026-4424 CVE-2026-5121`
+- Build log confirms: `Patch #33 (libarchive-3.3.3-Fix-CVE-2026-5121.patch)`
+
+**Affected File:** `libarchive/archive_read_support_format_iso9660.c`
+
+**Fix Applied:** Added bounds check to prevent integer overflow in zisofs block pointer allocation:
+```c
+if (file->pz_log2_bs < 15 || file->pz_log2_bs > 17) {
+    file->pz = 0;
+    return;
+}
+```
+
+## Limitations
+
+1. **Fedora: No hardening check** — L2 compilation check works (can detect disabled features), but no compiler flag analysis due to different build system.
+
+2. **Requires source access** — Needs SRPM via Brew (RHEL) or Koji (Fedora). Packages without accessible source cannot be fully analyzed.
+
+3. **LLM-based analysis** — Verdicts are generated using LLM reasoning and should be reviewed by security analysts before action.
+
+4. **Single-package scope** — Designed for targeted investigation of one CVE in one package. For container-wide scanning, use the main workflow.

--- a/src/exploit_iq_commons/data_models/checker_status.py
+++ b/src/exploit_iq_commons/data_models/checker_status.py
@@ -28,6 +28,7 @@ class PackageCheckerStatus(IntEnum):
     ERROR_FAILED_TO_DOWNLOAD_SRPM = 3
     PKG_IDENT_CVE_MISMATCH = 4
     PKG_INTEL_LOW_SCORE = 5
+    CONFLICTING_INTEL_EVIDENCE = 6
 
 
 PACKAGE_CHECKER_STATUS_DESCRIPTIONS: dict[PackageCheckerStatus, str] = {
@@ -43,6 +44,8 @@ PACKAGE_CHECKER_STATUS_DESCRIPTIONS: dict[PackageCheckerStatus, str] = {
         "CVE does not apply to target package - RHSA does not list this package",
     PackageCheckerStatus.PKG_INTEL_LOW_SCORE:
         "Intel quality score below threshold - insufficient information for reliable analysis",
+    PackageCheckerStatus.CONFLICTING_INTEL_EVIDENCE:
+        "Code analysis conflicts with RHSA 'not affected' assessment - manual review required",
 }
 
 CHECKER_FAILURE_ERROR_TYPES: dict[PackageCheckerStatus, str] = {
@@ -65,6 +68,11 @@ class PackageIdentifyResult(BaseModel):
 
     is_target_package_affected: EnumIdentifyResult = EnumIdentifyResult.UNKNOWN
     is_target_package_fixed: EnumIdentifyResult = EnumIdentifyResult.UNKNOWN
+    
+    rhsa_fix_state: str | None = Field(
+        default=None,
+        description="Raw RHSA fix_state value when is_target_package_affected is based on RHSA assessment"
+    )
     
     conclusion_reason: str = Field(
         default="",

--- a/src/vuln_analysis/functions/cve_checker_report.py
+++ b/src/vuln_analysis/functions/cve_checker_report.py
@@ -79,6 +79,12 @@ _JUSTIFICATION_LABEL_TO_STATUS: dict[str, _StatusLiteral] = {
 _POLICY_MAX_RPM_LIST_ITEMS = 5
 _POLICY_RHSA_STATEMENT_CAP = 400
 
+_POLICY_MAX_PACKAGE_STATE_ITEMS = 8
+
+_BUILD_LOG_EXCERPT_MAX_LINES = 8
+
+_EVIDENCE_CHAIN_ITEM_CAP = 8
+
 
 def _detect_intel_conflict(ctx, final_label: str) -> bool:
     """Detect when final verdict contradicts RHSA 'not affected' assessment.
@@ -94,10 +100,6 @@ def _detect_intel_conflict(ctx, final_label: str) -> bool:
     if ctx.identify_result.rhsa_fix_state != "not affected":
         return False
     return final_label == "vulnerable"
-_POLICY_MAX_PACKAGE_STATE_ITEMS = 8
-
-_BUILD_LOG_EXCERPT_MAX_LINES = 8
-_EVIDENCE_CHAIN_ITEM_CAP = 8
 
 
 def _md_section_header(title: str) -> list[str]:

--- a/src/vuln_analysis/functions/cve_checker_report.py
+++ b/src/vuln_analysis/functions/cve_checker_report.py
@@ -979,8 +979,7 @@ def _build_analysis(
         )
         label = "conflicting_evidence"
         status = "UNKNOWN"
-        if ctx:
-            ctx.status = PackageCheckerStatus.CONFLICTING_INTEL_EVIDENCE
+        ctx.status = PackageCheckerStatus.CONFLICTING_INTEL_EVIDENCE
 
     summary = _strip_build_agent_absence_boilerplate(blocks.executive_summary.strip())
     reason = _format_justification_reason(blocks, label_override=label if label != blocks.justification_label else None)

--- a/src/vuln_analysis/functions/cve_checker_report.py
+++ b/src/vuln_analysis/functions/cve_checker_report.py
@@ -36,7 +36,12 @@ from pydantic import Field
 
 from exploit_iq_commons.logging.loggers_factory import LoggingFactory, trace_id
 from exploit_iq_commons.data_models.input import AgentMorpheusEngineInput
-from exploit_iq_commons.data_models.checker_status import L1InvestigationResult, L2BuildResult
+from exploit_iq_commons.data_models.checker_status import (
+    EnumIdentifyResult,
+    L1InvestigationResult,
+    L2BuildResult,
+    PackageCheckerStatus,
+)
 
 from nat.builder.context import Context
 from vuln_analysis.data_models.output import (
@@ -67,11 +72,28 @@ _JUSTIFICATION_LABEL_TO_STATUS: dict[str, _StatusLiteral] = {
     "requires_environment": "FALSE",
     "vulnerable": "TRUE",
     "uncertain": "UNKNOWN",
+    "conflicting_evidence": "UNKNOWN",
 }
 
 
 _POLICY_MAX_RPM_LIST_ITEMS = 5
 _POLICY_RHSA_STATEMENT_CAP = 400
+
+
+def _detect_intel_conflict(ctx, final_label: str) -> bool:
+    """Detect when final verdict contradicts RHSA 'not affected' assessment.
+    
+    Returns True if RHSA assessed the package as "not affected" but the
+    code/build analysis concluded it is vulnerable. This conflict requires
+    human review to determine if it's an RHSA error or an analysis bug.
+    """
+    if not ctx or not ctx.identify_result:
+        return False
+    if ctx.identify_result.is_target_package_affected != EnumIdentifyResult.NO:
+        return False
+    if ctx.identify_result.rhsa_fix_state != "not affected":
+        return False
+    return final_label == "vulnerable"
 _POLICY_MAX_PACKAGE_STATE_ITEMS = 8
 
 _BUILD_LOG_EXCERPT_MAX_LINES = 8
@@ -600,6 +622,11 @@ _REASON_BY_LABEL: dict[str, str] = {
         "Labeled uncertain because patch, spec, build, and source evidence are "
         "insufficient or conflicting."
     ),
+    "conflicting_evidence": (
+        "Labeled conflicting evidence because RHSA assessed this package as 'not affected' "
+        "but code analysis found vulnerable patterns. Manual review required to determine "
+        "if this is an RHSA assessment error or an analysis false positive."
+    ),
 }
 
 
@@ -611,9 +638,15 @@ def _all_patch_checks_failed(blocks: ReportBlocks) -> bool:
     )
 
 
-def _format_justification_reason(blocks: ReportBlocks) -> str:
-    """One-sentence VEX label rationale (outcome voice); evidence lives in details."""
-    label = blocks.justification_label
+def _format_justification_reason(blocks: ReportBlocks, label_override: str | None = None) -> str:
+    """One-sentence VEX label rationale (outcome voice); evidence lives in details.
+    
+    Args:
+        blocks: Report blocks containing investigation data
+        label_override: Optional label to use instead of blocks.justification_label
+                       (used when label is changed due to conflict detection)
+    """
+    label = label_override if label_override else blocks.justification_label
     if label == "vulnerable":
         if _all_patch_checks_failed(blocks):
             return (
@@ -936,8 +969,19 @@ def _build_analysis(
     label = blocks.justification_label
     status: _StatusLiteral = _JUSTIFICATION_LABEL_TO_STATUS.get(label, "UNKNOWN")
 
+    # Check for conflict between RHSA "not affected" assessment and analysis verdict
+    if _detect_intel_conflict(ctx, label):
+        logger.warning(
+            "Intel conflict detected: RHSA says 'not affected' but analysis concluded 'vulnerable'. "
+            "Flagging for human review."
+        )
+        label = "conflicting_evidence"
+        status = "UNKNOWN"
+        if ctx:
+            ctx.status = PackageCheckerStatus.CONFLICTING_INTEL_EVIDENCE
+
     summary = _strip_build_agent_absence_boilerplate(blocks.executive_summary.strip())
-    reason = _format_justification_reason(blocks)
+    reason = _format_justification_reason(blocks, label_override=label if label != blocks.justification_label else None)
     details = _build_details_md(blocks)
 
     return [

--- a/src/vuln_analysis/functions/cve_package_code_agent.py
+++ b/src/vuln_analysis/functions/cve_package_code_agent.py
@@ -194,6 +194,8 @@ def _format_policy_context_for_l1_report(
             suffix = f" (+ {len(affected) - len(shown)} more)" if len(affected) > len(shown) else ""
             lines.append(f"**Affected NVRs from identify:** {', '.join(f'`{n}`' for n in shown)}{suffix}")
             lines.append(f"  - is_target_package_affected: `{identify_result.is_target_package_affected.value}`")
+            if identify_result.conclusion_reason:
+                lines.append(f"  - conclusion_reason: `{identify_result.conclusion_reason}`")
 
         if fixed:
             shown = fixed[:_POLICY_MAX_RPM_LIST_ITEMS]

--- a/src/vuln_analysis/utils/package_identifier.py
+++ b/src/vuln_analysis/utils/package_identifier.py
@@ -128,7 +128,9 @@ class PackageIdentifier:
         ``affected_release`` when Red Hat published either list; else
         ``PKG_IDENT_CVE_MISMATCH``.
         Step 2 — Vulnerability posture: ``PKG_IDENT_NOT_VUL`` when RHSA/NVD
-        shows the target is not affected or already fixed.
+        shows the target is already fixed, or when fix_state is "will not fix"
+        or "out of support scope". When fix_state is "not affected", investigation
+        continues (status=OK) to verify the RHSA assessment and catch potential errors.
         """
 
         package_identify = PackageIdentifyResult()
@@ -146,8 +148,16 @@ class PackageIdentifier:
 
         package_identify.is_target_package_fixed = self._is_target_package_fixed(intel,package_identify)
         
-        if package_identify.is_target_package_affected == EnumIdentifyResult.NO or package_identify.is_target_package_fixed == EnumIdentifyResult.YES:
+        # Determine if we should early-exit with PKG_IDENT_NOT_VUL
+        if package_identify.is_target_package_fixed == EnumIdentifyResult.YES:
+            # Package is already running the fixed version
             status = PackageCheckerStatus.PKG_IDENT_NOT_VUL
+        elif package_identify.is_target_package_affected == EnumIdentifyResult.NO:
+            # RHSA says not affected - check if we should continue investigation
+            # "not affected" continues to verify; other states (will not fix, out of support) early-exit
+            if package_identify.rhsa_fix_state != "not affected":
+                status = PackageCheckerStatus.PKG_IDENT_NOT_VUL
+            # else: status stays OK, continue investigation to verify RHSA assessment
             
         return status, package_identify
 
@@ -243,6 +253,8 @@ class PackageIdentifier:
                         matched_ps.fix_state, target_name, target_distro, result.value
                     )
                     if result == EnumIdentifyResult.NO:
+                        # Store the raw fix_state for downstream decision-making
+                        package_identify.rhsa_fix_state = matched_ps.fix_state.lower().strip() if matched_ps.fix_state else None
                         package_identify.conclusion_reason = (
                             f"RHSA fix_state indicates package is not vulnerable for analysis. "
                             f"Package: {target_name}, Distro: {target_distro or 'unknown'}, "

--- a/tests/test_package_identifier.py
+++ b/tests/test_package_identifier.py
@@ -214,8 +214,13 @@ class TestPackageIdentifierWithFixState:
         assert status == PackageCheckerStatus.PKG_IDENT_NOT_VUL
         assert "Will not fix" in result.conclusion_reason
 
-    def test_cve_2016_8687_rhel6_not_affected(self):
-        """CVE-2016-8687 on RHEL 6 should be NO (Not affected)."""
+    def test_cve_2016_8687_rhel6_not_affected_continues_investigation(self):
+        """CVE-2016-8687 on RHEL 6 'Not affected' should continue investigation (status=OK).
+        
+        When RHSA says 'not affected', we continue investigation to verify the assessment
+        and catch potential RHSA errors. The rhsa_fix_state is preserved for downstream
+        conflict detection.
+        """
         target = TargetPackage(
             name="libarchive",
             version="3.0.3",
@@ -258,12 +263,51 @@ class TestPackageIdentifierWithFixState:
         status, result = identifier.identify(intel)
         
         assert result.is_target_package_affected == EnumIdentifyResult.NO
-        assert status == PackageCheckerStatus.PKG_IDENT_NOT_VUL
+        # "not affected" continues investigation instead of early exit
+        assert status == PackageCheckerStatus.OK
+        # rhsa_fix_state is preserved for conflict detection
+        assert result.rhsa_fix_state == "not affected"
         # Verify conclusion_reason is populated with RHSA details
         assert "RHSA fix_state" in result.conclusion_reason
         assert "Not affected" in result.conclusion_reason
         assert "libarchive" in result.conclusion_reason
         assert "el6" in result.conclusion_reason
+
+    def test_out_of_support_scope_early_exits(self):
+        """RHSA 'out of support scope' should early-exit with PKG_IDENT_NOT_VUL.
+        
+        Unlike 'not affected', 'out of support scope' means Red Hat won't provide
+        further assessment, so we don't continue investigation.
+        """
+        target = TargetPackage(
+            name="oldlib",
+            version="1.0.0",
+            release="1.el5",
+            arch="x86_64",
+        )
+        
+        intel = CveIntel(
+            vuln_id="CVE-2024-0002",
+            nvd=None,
+            rhsa=CveIntelRhsa(
+                package_state=[
+                    CveIntelRhsa.PackageState(
+                        product_name="Red Hat Enterprise Linux 5",
+                        fix_state="Out of support scope",
+                        package_name="oldlib",
+                        cpe="cpe:/o:redhat:enterprise_linux:5",
+                    ),
+                ],
+            ),
+        )
+        
+        identifier = PackageIdentifier(target)
+        status, result = identifier.identify(intel)
+        
+        assert result.is_target_package_affected == EnumIdentifyResult.NO
+        # "out of support scope" still triggers early exit
+        assert status == PackageCheckerStatus.PKG_IDENT_NOT_VUL
+        assert result.rhsa_fix_state == "out of support scope"
 
     def test_falls_back_to_nvd_when_no_fix_state(self):
         """When RHSA has no fix_state, should fall back to NVD version check."""


### PR DESCRIPTION

Adds user-facing upstream documentation for the RPM CVE Checker feature, enabling external Red Hat and Fedora engineering teams to understand and use the targeted package vulnerability analysis mode.

Changes

Add new RPM-CVE-CHECKER.md at repo root (~250 lines) with comprehensive user guide:

Supported distributions (RHEL full L1+L2, Fedora L1 + L2 compilation check only)
How it works (Mermaid flowchart showing L1/L2 analysis flow)
Input format with RHEL and Fedora JSON examples
Configuration options (rpm_user_type, cache directories, Brew/Koji profiles)
Verdict explanations with justification labels
Example walkthrough using CVE-2026-5121 (libarchive)
Limitations
Add RPM CVE Checker section to README.md:

25-line overview with quick example
Link to detailed documentation

----------------------------------------------------------------------------
RHSA "Not Affected" Handling Improvement
Problem

When RHSA states a package is "not affected," the checker previously stopped immediately without further analysis. While RHSA assessments are highly reliable, this early-exit prevented catching rare human errors in RHSA data.

Before

RHSA "not affected" triggered immediate early exit
No validation of RHSA assessment
Potential RHSA errors went undetected
After

RHSA "not affected" continues full code and build analysis
Agents see "RHSA says not affected" as strong context and can validate or challenge it
Conflicts flagged as CONFLICTING_INTEL_EVIDENCE with status UNKNOWN for human review
Unchanged behavior

"Will not fix" and "Out of support scope" states still trigger early exit (these confirm CVE applies, just won't be patched)
RHSA assessment preserved and visible in final report
Expected outcomes

Most cases: Analysis confirms RHSA → normal "not vulnerable" verdict
Rare cases: Analysis contradicts RHSA → flagged for human review