### PR TITLE
Appeng 5400 return client error when language was not detected

### DIFF
--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -198,8 +198,9 @@ class SourceCodeGitLoader(BlobLoader):
                             env=clone_env,
                         )
                     except GitCommandError as e:
+                        logger.error("Failed to clone repository '%s': %s", self.clone_url, e)
                         raise ValueError(
-                            f"Failed to clone repository '{self.clone_url}': {e}"
+                            f"Failed to clone repository '{self.clone_url}'"
                         ) from e
                     # depth=1 implies --single-branch, which narrows the fetch
                     # refspec to only the default branch.  Widen it so that

--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -185,8 +185,22 @@ class SourceCodeGitLoader(BlobLoader):
                     repo = self._clone_with_credential(credential_id)
                     credential_clone = True
                 else:
-                    # Create a shallow clone of the repository without checking out
-                    repo = Repo.clone_from(self.clone_url, self.repo_path, depth=1, no_checkout=True)
+                    # Create a shallow clone of the repository without checking out.
+                    # GIT_TERMINAL_PROMPT=0: never block on username/password prompts.
+
+                    clone_env = {"GIT_TERMINAL_PROMPT": "0"}
+                    try:
+                        repo = Repo.clone_from(
+                            self.clone_url,
+                            self.repo_path,
+                            depth=1,
+                            no_checkout=True,
+                            env=clone_env,
+                        )
+                    except GitCommandError as e:
+                        raise ValueError(
+                            f"Failed to clone public repository '{self.clone_url}': {e}"
+                        ) from e
                     # depth=1 implies --single-branch, which narrows the fetch
                     # refspec to only the default branch.  Widen it so that
                     # fetching any branch creates a remote-tracking ref and

--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -199,7 +199,7 @@ class SourceCodeGitLoader(BlobLoader):
                         )
                     except GitCommandError as e:
                         raise ValueError(
-                            f"Failed to clone public repository '{self.clone_url}': {e}"
+                            f"Failed to clone repository '{self.clone_url}': {e}"
                         ) from e
                     # depth=1 implies --single-branch, which narrows the fetch
                     # refspec to only the default branch.  Widen it so that

--- a/src/vuln_analysis/functions/cve_generate_vdbs.py
+++ b/src/vuln_analysis/functions/cve_generate_vdbs.py
@@ -37,6 +37,13 @@ logger = LoggingFactory.get_agent_logger(__name__)
 class GitCloneError(Exception):
     """Raised when cloning or updating a repo for document collection fails."""
 
+
+class EcosystemNotDetectedError(Exception):
+    """Raised when no ecosystem can be detected from cloned repo manifests."""
+
+    def __init__(self, message: str = "No ecosystem detected from repo manifests") -> None:
+        super().__init__(message)
+
 class CVEGenerateVDBsToolConfig(FunctionBaseConfig, name="cve_generate_vdbs"):
     """
     Defines a function that generates a vector database from code repositories and documentation.
@@ -119,7 +126,8 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
                 documents.extend(embedder.collect_documents(si))
             except Exception as e:
                 logger.warning("Error collecting documents for source info %s: %s", si, e)
-                raise GitCloneError(e)
+                raise GitCloneError(f"Failed to clone repository {si.git_repo}--{e}")
+   
 
         # Warn and return early if no documents were collected
         if len(documents) == 0:
@@ -189,6 +197,7 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
         vdb_code_path = None
         vdb_doc_path = None
         code_index_path = None
+        ecosystem_detected = True
 
         base_image = message.image.name
         source_infos = message.image.source_info
@@ -239,6 +248,18 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
                         if detected is not None:
                             message.image.ecosystem = detected
                             logger.info("Detected ecosystem '%s' from repo manifests", detected.value)
+                        else:
+                            ecosystem_detected = False
+                            raise EcosystemNotDetectedError()
+
+        except EcosystemNotDetectedError:
+            failure_reason = "No ecosystem detected from repo manifests"
+            logger.error(
+                "No ecosystem detected from repo manifests for image '%s', source code info: %s",
+                base_image,
+                source_infos,
+            )
+            logger.warning("Ignoring VDB generation error and continuing with missing VDBs.")
 
         except Exception as e:
             failure_reason = f"Failure to build VDB , Error: {e}"
@@ -248,15 +269,12 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
                          e,
                          exc_info=True)
 
-            if not config.ignore_errors:
-                raise
-
             logger.warning("Ignoring VDB generation error and continuing with missing VDBs.")
 
         vdb_code_path = str(vdb_code_path) if vdb_code_path is not None else None
         vdb_doc_path = str(vdb_doc_path) if vdb_doc_path is not None else None
         code_index_path = str(code_index_path) if code_index_path is not None else None
-        code_index_success = True if code_index_path is not None else False
+        code_index_success = True if code_index_path is not None and ecosystem_detected else False
         if not code_index_success:
             message.failure_reason = failure_reason
 

--- a/src/vuln_analysis/functions/cve_generate_vdbs.py
+++ b/src/vuln_analysis/functions/cve_generate_vdbs.py
@@ -126,7 +126,8 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
                 documents.extend(embedder.collect_documents(si))
             except Exception as e:
                 logger.warning("Error collecting documents for source info %s: %s", si, e)
-                raise GitCloneError(f"Failed to clone repository {si.git_repo}--{e}")
+                logger.error("Failed to clone repository %s--%s", si.git_repo, e)
+                raise GitCloneError(f"Failed to clone repository {si.git_repo}")
    
 
         # Warn and return early if no documents were collected

--- a/src/vuln_analysis/functions/cve_http_output.py
+++ b/src/vuln_analysis/functions/cve_http_output.py
@@ -128,7 +128,7 @@ def _build_output_payload(
         report = FailureReport(
             scan_id=message.input.scan.id,
             error_type="processing-error",
-            error_message=f"Failed to clone repository {repo_url}--{message.input.failure_reason}",
+            error_message=message.input.failure_reason if message.input.failure_reason else "Unknown failure reason",
         )
         logger.info(f"Code index failed for scan {message.input.scan.id}, sending failure report to {failure_url}")
         return OutputPayload(json=report.model_dump_json(by_alias=True), url=failure_url, skip_mlops=True)

--- a/src/vuln_analysis/tools/tests/test_source_code_git_loader.py
+++ b/src/vuln_analysis/tools/tests/test_source_code_git_loader.py
@@ -1,5 +1,6 @@
 import pytest
 import shutil
+
 from exploit_iq_commons.utils.source_code_git_loader import SourceCodeGitLoader
 
 
@@ -23,6 +24,20 @@ from exploit_iq_commons.utils.source_code_git_loader import SourceCodeGitLoader
 ])
 def test_https_to_ssh_url(https_url, expected_ssh):
     assert SourceCodeGitLoader._https_to_ssh_url(https_url) == expected_ssh
+
+
+def test_public_clone_fails_instead_of_prompting(tmp_path):
+    """Unauthenticated clone of a missing/private repo must fail fast, not hang on a prompt."""
+    clone_url = "https://github.com/example/missing"
+    repo_path = tmp_path / "repo"
+
+    loader = SourceCodeGitLoader(repo_path=repo_path, clone_url=clone_url, ref="main")
+
+    with pytest.raises(ValueError, match=r"Failed to clone repository .+missing"):
+        loader.load_repo()
+
+    assert not repo_path.exists() or not (repo_path / ".git").exists()
+
 
 def test_load_repo_branch_checkout(tmp_path):
     """Branch names must be checkable after a shallow clone (APPENG-4896)."""


### PR DESCRIPTION
APPENG-5400: Scan request shall fail when the computer language of the git repository failed to be detected.

In addition, in case credential is not provided and when cloning for git repo result with user/pass prompt, fail the operation