### PR TITLE
feat: add cache invalidation automation

### DIFF
--- a/.tekton/cache-cleaner.yaml
+++ b/.tekton/cache-cleaner.yaml
@@ -1,0 +1,65 @@
+---
+# RBAC: The Tekton ServiceAccount (usually `pipeline`) needs `edit` (or a custom
+# Role) in target application namespaces to create/delete Jobs and mount PVCs
+# (e.g., exploit-iq-testings, exploit-iq-prod).
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: generic-cache-cleaner
+spec:
+  description: >-
+    Purges application cache from a PVC by spawning a short-lived Job in the
+    target namespace, waiting for completion, and removing the Job.
+  params:
+    - name: pvc-name
+      type: string
+      description: Name of the PersistentVolumeClaim holding the cache.
+    - name: namespace
+      type: string
+      description: Target namespace where the PVC lives (e.g., exploit-iq-testings).
+  steps:
+    - name: create-cache-cleaner-job
+      image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+      script: |
+        #!/bin/sh
+        set -eu
+
+        oc apply -f - <<EOF
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: cache-cleaner-job-$(params.pvc-name)
+          namespace: $(params.namespace)
+        spec:
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: cache-cleaner
+                  image: alpine:latest
+                  command:
+                    - /bin/sh
+                    - -c
+                    - 'rm -rf /data-to-clean/* && echo "Cache cleared successfully!"'
+                  volumeMounts:
+                    - name: cache-volume
+                      mountPath: /data-to-clean
+              volumes:
+                - name: cache-volume
+                  persistentVolumeClaim:
+                    claimName: $(params.pvc-name)
+        EOF
+
+    - name: wait-and-delete-cache-cleaner-job
+      image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+      script: |
+        #!/bin/sh
+        set -eu
+
+        oc wait --for=condition=complete \
+          "job/cache-cleaner-job-$(params.pvc-name)" \
+          -n "$(params.namespace)" \
+          --timeout=120s
+
+        oc delete "job/cache-cleaner-job-$(params.pvc-name)" \
+          -n "$(params.namespace)"


### PR DESCRIPTION
The purpose of this task is to create a generic mechanism to invalidate cache from PVCs in the ExploitIQ system: 
[Jira](https://redhat.atlassian.net/issues?filter=106533&selectedIssue=APPENG-5422)