### PR TITLE
Security: regenerate Maven wrapper before execution in build_tree and lock_file_parsers

### DIFF
--- a/src/exploit_iq_commons/utils/dep_tree.py
+++ b/src/exploit_iq_commons/utils/dep_tree.py
@@ -965,9 +965,49 @@ class GoDependencyTreeBuilder(DependencyTreeBuilder):
             return package_name
 
 
+_MAVEN_VERSION_RE = re.compile(r'^\d+\.\d+\.\d+$')
+
+
+def _extract_mvnw_maven_version(manifest_path: Path) -> str | None:
+    """Extract and validate the Maven version from the wrapper properties file."""
+    props = manifest_path / ".mvn" / "wrapper" / "maven-wrapper.properties"
+    if not props.is_file():
+        return None
+    try:
+        for line in props.read_text().splitlines():
+            if line.startswith("distributionUrl="):
+                match = re.search(r'apache-maven-(\d+\.\d+\.\d+)', line)
+                if match and _MAVEN_VERSION_RE.match(match.group(1)):
+                    return match.group(1)
+    except OSError:
+        pass
+    return None
+
+
+def resolve_mvn_command(manifest_path: Path) -> str:
+    """Return the Maven command to use for *manifest_path*.
+
+    If a ``mvnw`` wrapper exists, regenerate it from a trusted ``mvn``
+    binary (using the version declared in ``maven-wrapper.properties``)
+    to avoid executing an untrusted script.  Falls back to ``"mvn"``
+    when regeneration fails or the version cannot be determined.
+    """
+    if not (Path(manifest_path) / "mvnw").is_file():
+        return "mvn"
+    version = _extract_mvnw_maven_version(manifest_path)
+    if not version:
+        logger.warning("Could not extract valid Maven version from wrapper properties, using system mvn")
+        return "mvn"
+    logger.info("Regenerating Maven wrapper with version %s", version)
+    result = subprocess.run(["mvn", "wrapper:wrapper", f"-Dmaven={version}"], cwd=manifest_path)
+    if result.returncode == 0:
+        return "./mvnw"
+    logger.warning("Failed to regenerate Maven wrapper, falling back to system mvn")
+    return "mvn"
+
+
 class JavaDependencyTreeBuilder(DependencyTreeBuilder):
     DEP_SOURCE_DIR = "dependencies-sources"
-    _MAVEN_VERSION_RE = re.compile(r'^\d+\.\d+\.\d+$')
 
     def __init__(self, query: str):
         self._query = query
@@ -979,38 +1019,10 @@ class JavaDependencyTreeBuilder(DependencyTreeBuilder):
         p = Path(dir_path) / filename
         return p.is_file()
 
-    @staticmethod
-    def _extract_mvnw_maven_version(manifest_path: Path) -> str | None:
-        """Extract and validate the Maven version from the wrapper properties file."""
-        props = manifest_path / ".mvn" / "wrapper" / "maven-wrapper.properties"
-        if not props.is_file():
-            return None
-        try:
-            for line in props.read_text().splitlines():
-                if line.startswith("distributionUrl="):
-                    match = re.search(r'apache-maven-(\d+\.\d+\.\d+)', line)
-                    if match and JavaDependencyTreeBuilder._MAVEN_VERSION_RE.match(match.group(1)):
-                        return match.group(1)
-        except OSError:
-            pass
-        return None
-
     def install_dependencies(self, manifest_path: Path):
-        mvn_command = "mvn"
+        mvn_command = resolve_mvn_command(manifest_path)
         settings_path = os.getenv('JAVA_MAVEN_DEFAULT_SETTINGS_FILE_PATH','../../../../kustomize/base/settings.xml')
         source_path = self.DEP_SOURCE_DIR
-
-        if self.__check_file_exists(manifest_path, "mvnw"):
-            version = self._extract_mvnw_maven_version(manifest_path)
-            if version:
-                logger.info("Regenerating Maven wrapper with version %s", version)
-                result = subprocess.run(["mvn", "wrapper:wrapper", f"-Dmaven={version}"], cwd=manifest_path)
-                if result.returncode == 0:
-                    mvn_command = "./mvnw"
-                else:
-                    logger.warning("Failed to regenerate Maven wrapper, falling back to system mvn")
-            else:
-                logger.warning("Could not extract valid Maven version from wrapper properties, using system mvn")
 
         process_object = subprocess.run([mvn_command, "-s", settings_path, "dependency:copy-dependencies", "-Dclassifier=sources",
                                          "-DincludeScope=runtime", f"-DoutputDirectory={manifest_path.resolve()}/{source_path}"], cwd=manifest_path)
@@ -1059,13 +1071,10 @@ class JavaDependencyTreeBuilder(DependencyTreeBuilder):
                 logger.warning("Empty sources jar (size=0), possibly corrupt: %s", jar)
 
     def build_tree(self, manifest_path: Path) -> dict[str, list[str]]:
-        mvn_command = "mvn"
+        mvn_command = resolve_mvn_command(manifest_path)
         settings_path = os.getenv("JAVA_MAVEN_DEFAULT_SETTINGS_FILE_PATH", "../../../../kustomize/base/settings.xml")
         dependency_file = manifest_path / "dependency_tree.txt"
         package_name = self._query.split(",")[0]
-
-        if self.__check_file_exists(manifest_path, "mvnw"):
-            mvn_command = "./mvnw"
 
         if is_maven_gav(package_name):
             subprocess.run(

--- a/src/exploit_iq_commons/utils/dep_tree.py
+++ b/src/exploit_iq_commons/utils/dep_tree.py
@@ -999,10 +999,19 @@ def resolve_mvn_command(manifest_path: Path) -> str:
         logger.warning("Could not extract valid Maven version from wrapper properties, using system mvn")
         return "mvn"
     logger.info("Regenerating Maven wrapper with version %s", version)
-    result = subprocess.run(["mvn", "wrapper:wrapper", f"-Dmaven={version}"], cwd=manifest_path)
+    result = subprocess.run(
+        ["mvn", "wrapper:wrapper", f"-Dmaven={version}"],
+        cwd=manifest_path,
+        capture_output=True,
+        text=True,
+    )
     if result.returncode == 0:
         return "./mvnw"
-    logger.warning("Failed to regenerate Maven wrapper, falling back to system mvn")
+    logger.warning(
+        "Failed to regenerate Maven wrapper (exit %d): %s",
+        result.returncode,
+        result.stderr or result.stdout,
+    )
     return "mvn"
 
 

--- a/src/vuln_analysis/utils/lock_file_parsers.py
+++ b/src/vuln_analysis/utils/lock_file_parsers.py
@@ -24,7 +24,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from exploit_iq_commons.utils.dep_tree import TRANSITIVE_ENV_NAME, run_command
+from exploit_iq_commons.utils.dep_tree import TRANSITIVE_ENV_NAME, resolve_mvn_command, run_command
 from exploit_iq_commons.utils.java_utils import parse_depgraph_line
 from exploit_iq_commons.logging.loggers_factory import LoggingFactory
 
@@ -207,7 +207,7 @@ def _generate_dependency_tree_txt(repo_path: Path) -> bool:
     Returns:
         True if successful, False otherwise.
     """
-    mvn_cmd = "./mvnw" if (repo_path / "mvnw").exists() else "mvn"
+    mvn_cmd = resolve_mvn_command(repo_path)
     output_file = repo_path / "dependency_tree.txt"
 
     settings_path = os.getenv("JAVA_MAVEN_DEFAULT_SETTINGS_FILE_PATH")


### PR DESCRIPTION
  - Extract resolve_mvn_command() and _extract_mvnw_maven_version() as module-level functions in dep_tree.py
  - Add mvnw security check to JavaDependencyTreeBuilder.build_tree() (previously used ./mvnw without validation)
  - Add mvnw security check to _generate_dependency_tree_txt() in lock_file_parsers.py (previously used ./mvnw without validation)