### PR TITLE
A few fixes

### DIFF
--- a/kustomize/base/exploitiq_mcp_server.yaml
+++ b/kustomize/base/exploitiq_mcp_server.yaml
@@ -1,3 +1,39 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: exploitiq-mcp-server-sa
+  labels:
+    app: exploit-iq
+    component: exploitiq-mcp-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: exploitiq-mcp-server-anyuid-scc
+  labels:
+    app: exploit-iq
+    component: exploitiq-mcp-server
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["anyuid"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: exploitiq-mcp-server-anyuid-scc
+  labels:
+    app: exploit-iq
+    component: exploitiq-mcp-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: exploitiq-mcp-server-anyuid-scc
+subjects:
+  - kind: ServiceAccount
+    name: exploitiq-mcp-server-sa
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,11 +55,13 @@ spec:
         app: exploit-iq
         component: exploitiq-mcp-server
     spec:
-      serviceAccountName: exploit-iq-client-sa
+      serviceAccountName: exploitiq-mcp-server-sa
       imagePullSecrets: []
       containers:
         - name: exploitiq-mcp-server
-          image: quay.io/exploit-iq/exploitiq-mcp-server:latest
+          securityContext:
+            runAsNonRoot: true
+          image: quay.io/ecosystem-appeng/exploitiq-mcp-server:latest
           imagePullPolicy: Always
           ports:
             - name: http
@@ -40,6 +78,10 @@ spec:
               value: "3000"
             - name: NODE_EXTRA_CA_CERTS
               value: /etc/tls/tls.crt
+            - name: EXPLOITIQ_READ_ONLY
+              value: "true"
+            - name: EXPLOITIQ_REDACT_RESPONSES
+              value: "true"
             - name: OPENSHIFT_DOMAIN
               valueFrom:
                 secretKeyRef:

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -100,5 +100,5 @@ images:
   - name: quay.io/ecosystem-appeng/agent-morpheus-client
     newTag: latest
 
-  - name: quay.io/exploit-iq/exploitiq-mcp-server
+  - name: quay.io/ecosystem-appeng/exploitiq-mcp-server
     newTag: latest

--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -282,16 +282,16 @@ class SourceCodeGitLoader(BlobLoader):
             repo.git.fetch("origin", f"refs/tags/{self.ref}:refs/tags/{self.ref}", "--depth=1", "--force")
             logger.info("Fetched ref '%s' as tag", self.ref)
             return
-        except GitCommandError as e:
-            logger.debug("Tag fetch failed for '%s': %s", self.ref, e)
+        except GitCommandError:
+            logger.warning("Ref '%s' is not a tag, retrying as branch/commit SHA", self.ref)
 
         # Not a tag — try as a branch or commit SHA
         try:
             repo.git.fetch("origin", self.ref, "--depth=1", "--force")
             logger.info("Fetched ref '%s' as branch/commit", self.ref)
             return
-        except GitCommandError as e:
-            logger.debug("Branch/commit fetch failed for '%s': %s", self.ref, e)
+        except GitCommandError:
+            logger.warning("Ref '%s' not found on remote, checking if it exists locally", self.ref)
 
         # Neither fetch worked — check if ref already exists locally
         try:

--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -282,16 +282,16 @@ class SourceCodeGitLoader(BlobLoader):
             repo.git.fetch("origin", f"refs/tags/{self.ref}:refs/tags/{self.ref}", "--depth=1", "--force")
             logger.info("Fetched ref '%s' as tag", self.ref)
             return
-        except GitCommandError:
-            logger.warning("Ref '%s' is not a tag, retrying as branch/commit SHA", self.ref)
+        except GitCommandError as e:
+            logger.warning("Ref '%s' is not a tag, retrying as branch/commit SHA: %s", self.ref, e)
 
         # Not a tag — try as a branch or commit SHA
         try:
             repo.git.fetch("origin", self.ref, "--depth=1", "--force")
             logger.info("Fetched ref '%s' as branch/commit", self.ref)
             return
-        except GitCommandError:
-            logger.warning("Ref '%s' not found on remote, checking if it exists locally", self.ref)
+        except GitCommandError as e:
+            logger.warning("Ref '%s' not found on remote, checking if it exists locally: %s", self.ref, e)
 
         # Neither fetch worked — check if ref already exists locally
         try:

--- a/src/vuln_analysis/functions/cve_verify_vuln_package.py
+++ b/src/vuln_analysis/functions/cve_verify_vuln_package.py
@@ -600,6 +600,7 @@ async def cve_verify_vuln_package(config: CVEVerifyVulnPackageConfig, builder: B
 
             vuln_sbom_packages: list[VulnerableSBOMPackage] = []
             checked_not_vulnerable: list[CheckedNotVulnerablePackage] = []
+            seen_not_vulnerable: set[tuple[str, str]] = set()
             intel_sources: list[str] = [vp["source"] for vp in vuln_packages]
 
             found_vulnerable = False
@@ -692,11 +693,14 @@ async def cve_verify_vuln_package(config: CVEVerifyVulnPackageConfig, builder: B
                         found_vulnerable = True
                         break
                     else:
-                        checked_not_vulnerable.append(CheckedNotVulnerablePackage(
-                            name=match.dep_name or pkg_name,
-                            version=match.installed_version or "unknown",
-                            reason=reason
-                        ))
+                        pkg_key = (match.dep_name or pkg_name, match.installed_version or "unknown")
+                        if pkg_key not in seen_not_vulnerable:
+                            seen_not_vulnerable.add(pkg_key)
+                            checked_not_vulnerable.append(CheckedNotVulnerablePackage(
+                                name=pkg_key[0],
+                                version=pkg_key[1],
+                                reason=reason
+                            ))
 
             # Stdlib/toolchain fallback: when no packages matched and it's a language ecosystem
             no_packages_found = not vuln_sbom_packages and not checked_not_vulnerable

--- a/src/vuln_analysis/utils/llm_engine_utils.py
+++ b/src/vuln_analysis/utils/llm_engine_utils.py
@@ -240,7 +240,7 @@ def build_no_vuln_packages_output(
         n = len(checked_not_vulnerable)
         reasons = {pkg.reason for pkg in checked_not_vulnerable}
         package_lines = "\n".join(
-            f"- {pkg.name}" for pkg in checked_not_vulnerable
+            f"- {pkg.name} ({pkg.version})" for pkg in checked_not_vulnerable
         )
         if len(reasons) == 1:
             shared_reason = next(iter(reasons))
@@ -253,7 +253,7 @@ def build_no_vuln_packages_output(
                              f"{package_lines}")
         else:
             package_lines_with_reason = "\n".join(
-                f"- {pkg.name} — {pkg.reason}"
+                f"- {pkg.name} ({pkg.version}) — {pkg.reason}"
                 for pkg in checked_not_vulnerable
             )
             summary = f"Not vulnerable — {n} package(s) checked."

--- a/src/vuln_analysis/utils/llm_engine_utils.py
+++ b/src/vuln_analysis/utils/llm_engine_utils.py
@@ -237,15 +237,30 @@ def build_no_vuln_packages_output(
     checked_not_vulnerable: list[CheckedNotVulnerablePackage] | None = None
 ) -> AgentMorpheusEngineOutput:
     if checked_not_vulnerable:
-        package_details = "; ".join(
-            f"{pkg.name}@{pkg.version}: {pkg.reason}" for pkg in checked_not_vulnerable
+        n = len(checked_not_vulnerable)
+        reasons = {pkg.reason for pkg in checked_not_vulnerable}
+        package_lines = "\n".join(
+            f"- {pkg.name}" for pkg in checked_not_vulnerable
         )
-        summary = (f"Packages were checked but determined not vulnerable. "
-                   f"Details: {package_details}")
-        justification_reason = (f"The following packages were checked and found not vulnerable: "
-                                f"{package_details}")
-        response_text = (f"The VulnerableDependencyChecker found matching packages but the LLM "
-                         f"determined they are not vulnerable. Details: {package_details}")
+        if len(reasons) == 1:
+            shared_reason = next(iter(reasons))
+            summary = f"Not vulnerable — {shared_reason}."
+            justification_reason = (f"Not vulnerable — {shared_reason}. {n} package(s)\n"
+                                    f"  checked:\n"
+                                    f"{package_lines}")
+            response_text = (f"Version check completed — {n} package(s) matched but none are vulnerable. "
+                             f"Reason: {shared_reason}.\n\n"
+                             f"{package_lines}")
+        else:
+            package_lines_with_reason = "\n".join(
+                f"- {pkg.name} — {pkg.reason}"
+                for pkg in checked_not_vulnerable
+            )
+            summary = f"Not vulnerable — {n} package(s) checked."
+            justification_reason = (f"Not vulnerable. {n} package(s) checked:\n\n"
+                                    f"{package_lines_with_reason}")
+            response_text = (f"Version check completed — {n} package(s) matched but none are vulnerable.\n\n"
+                             f"{package_lines_with_reason}")
     else:
         summary = ("The VulnerableDependencyChecker did not find any vulnerable packages "
                    "or dependencies in the SBOM.")

--- a/src/vuln_analysis/utils/version_check.py
+++ b/src/vuln_analysis/utils/version_check.py
@@ -333,7 +333,7 @@ def _deterministic_first_patched_check(
     reference = version_func(first_patched)
     is_vulnerable = installed < reference
     return is_vulnerable, (
-        f"Installed {installed_version} "
+        f"Installed version {installed_version} "
         f"{'<' if is_vulnerable else '>='} "
         f"first_patched {first_patched}"
     )
@@ -348,7 +348,7 @@ def _deterministic_nvd_range_check(
     version_range = [_intel_value(version_info.get(key)) for key in NVD_RANGE_KEYS]
     in_range = _check_version_in_range(installed_version, version_range, ecosystem)
     return in_range, (
-        f"Installed {installed_version} "
+        f"Installed version {installed_version} "
         f"{'in' if in_range else 'outside'} "
         f"NVD range"
     )


### PR DESCRIPTION
  - Add dedicated ServiceAccount, Role, and RoleBinding for MCP server (anyuid SCC)
  - Switch MCP server image to quay.io/ecosystem-appeng/ registry
  - Add runAsNonRoot security context and EXPLOITIQ_READ_ONLY/REDACT_RESPONSES env vars
  - Update kustomization image reference to match new registry
  - Upgrade git loader fetch failure logs from debug to warning for better troubleshooting
  - Deduplicate checked_not_vulnerable packages using seen_not_vulnerable set
  - Improve justification output: group packages by shared reason, show package names without version