### PR TITLE
feat(nginx): replace docker.io nginx with Red Hat hardened image

### DIFF
--- a/kustomize/base/nginx.yaml
+++ b/kustomize/base/nginx.yaml
@@ -20,21 +20,36 @@ spec:
         component: nginx-cache
     spec:
       imagePullSecrets: []
-      containers:
-        - name: nginx
-          image: docker.io/nginxinc/nginx-unprivileged:1.27
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: http
-              protocol: TCP
-              containerPort: 8080
-          resources:
-            limits:
-              memory: "256Mi"
-              cpu: "250m"
-            requests:
-              memory: "100Mi"
-              cpu: "100m"
+      initContainers:
+        - name: render-nginx-config
+          image: registry.redhat.io/ubi9/python-312@sha256:55ddb67dcfc6c7ec072fce58753910b290c2903b10cd71d0d64c631d44ef4ab0
+          command: ["python3", "-c"]
+          args:
+            - |
+              import os, sys, string
+              from pathlib import Path
+
+              required = [
+                  "SERPAPI_API_KEY", "NVIDIA_API_KEY", "OPENAI_API_KEY",
+                  "NGC_API_KEY", "NGC_ORG_ID", "NGINX_UPSTREAM_NVAI",
+                  "NGINX_UPSTREAM_NIM_LLM", "NGINX_UPSTREAM_NIM_EMBED",
+                  "NGINX_UPSTREAM_OPENAI",
+              ]
+              missing = [v for v in required if v not in os.environ]
+              if missing:
+                  print(f"missing required variables: {', '.join(missing)}", file=sys.stderr)
+                  sys.exit(1)
+
+              def render_dir(src_dir, dst_dir):
+                  src, dst = Path(src_dir), Path(dst_dir)
+                  dst.mkdir(parents=True, exist_ok=True)
+                  for tmpl in src.glob("*.conf.template"):
+                      out = dst / tmpl.stem
+                      out.write_text(string.Template(tmpl.read_text()).safe_substitute(os.environ))
+                      print(f"rendered: {tmpl} -> {out}")
+
+              render_dir("/templates/routes", "/generated/routes")
+              render_dir("/templates/variables", "/generated/variables")
           env:
             - name: SERPAPI_API_KEY
               valueFrom:
@@ -46,7 +61,6 @@ spec:
                 secretKeyRef:
                   key: nvidia_api_key
                   name: exploit-iq-secret
-
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -66,12 +80,33 @@ spec:
               value: https://integrate.api.nvidia.com
           volumeMounts:
             - name: routes
-              mountPath: /etc/nginx/templates/routes
+              mountPath: /templates/routes
+              readOnly: true
             - name: variables
-              mountPath: /etc/nginx/templates/variables
+              mountPath: /templates/variables
+              readOnly: true
+            - name: extra-config
+              mountPath: /generated
+      containers:
+        - name: nginx
+          image: registry.access.redhat.com/hi/nginx:1.30.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 8080
+          resources:
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+            requests:
+              memory: "100Mi"
+              cpu: "100m"
+          volumeMounts:
             - name: config
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+              readOnly: true
             - name: extra-config
               mountPath: /etc/nginx/conf.d
             - name: cache

--- a/kustomize/overlays/remote-nim-all/nginx-patch.yaml
+++ b/kustomize/overlays/remote-nim-all/nginx-patch.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   template:
     spec:
-      containers:
-        - name: nginx
+      initContainers:
+        - name: render-nginx-config
           env:
             - name: NGINX_UPSTREAM_NIM_LLM
               value: https://integrate.api.nvidia.com

--- a/kustomize/overlays/self-hosted-llama3.1-70b-4bit/nginx-patch.yaml
+++ b/kustomize/overlays/self-hosted-llama3.1-70b-4bit/nginx-patch.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   template:
     spec:
-      containers:
-        - name: nginx
+      initContainers:
+        - name: render-nginx-config
           env:
             - name: NGINX_UPSTREAM_NIM_LLM
               value: http://llama3-1-70b-instruct-4bit.exploit-iq-models.svc.cluster.local:8000

--- a/kustomize/overlays/tests/nginx-patch.yaml
+++ b/kustomize/overlays/tests/nginx-patch.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   template:
     spec:
-      containers:
-        - name: nginx
+      initContainers:
+        - name: render-nginx-config
           env:
             - name: NGINX_UPSTREAM_NIM_EMBED
               value: http://localhost:8000


### PR DESCRIPTION
Closes [APPENG-5492](https://redhat.atlassian.net/browse/APPENG-5492)

Migration to [Red Hat supported container images](https://images.redhat.com/?search=nginx&name=nginx) required by security policy compliance.

The upstream nginx approach for environment variable substitution in config templates (https://hub.docker.com/_/nginx#using-environment-variables-in-nginx-configuration-new-in-119) cant be used directly because Red Hat supported nginx container images dont provide this functionality.

The test environment is available in ns `daboogie-eiq`