### PR TITLE
Appeng 3789 allow specifying manifest path and ecosystem for single repo scans

### DIFF
--- a/src/exploit_iq_commons/utils/chain_of_calls_retriever_factory.py
+++ b/src/exploit_iq_commons/utils/chain_of_calls_retriever_factory.py
@@ -26,7 +26,8 @@ from exploit_iq_commons.utils.java_chain_of_calls_retriever import JavaChainOfCa
 
 def get_chain_of_calls_retriever(ecosystem: Ecosystem, documents: List[Document], manifest_path: Path, query: str,
                                  code_source_info: SourceDocumentsInfo,
-                                 uber_jar_file_threshold: int) -> ChainOfCallsRetrieverBase:
+                                 uber_jar_file_threshold: int,
+                                 manifest_relative_path: str | None) -> ChainOfCallsRetrieverBase:
     """
     Get an ecosystem(e.g programming language) parameter, and returns the right language functions parser associated
      with the ecosystem.
@@ -35,6 +36,7 @@ def get_chain_of_calls_retriever(ecosystem: Ecosystem, documents: List[Document]
     :param manifest_path:
     :param documents:
     :param ecosystem: the desired programming language parser.
+    :param manifest_relative_path: the manifest relative path
     :return:
     The right language functions parser associated to the ecosystem, if not exists, return ABC parent that
      doesn't do anything
@@ -45,6 +47,7 @@ def get_chain_of_calls_retriever(ecosystem: Ecosystem, documents: List[Document]
                                          manifest_path,
                                          query,
                                          code_source_info,
-                                         uber_jar_file_threshold=uber_jar_file_threshold)
+                                         uber_jar_file_threshold=uber_jar_file_threshold,
+                                         manifest_relative_path=manifest_relative_path)
     else:
         return ChainOfCallsRetriever(documents, ecosystem, manifest_path)

--- a/src/exploit_iq_commons/utils/document_embedding.py
+++ b/src/exploit_iq_commons/utils/document_embedding.py
@@ -473,10 +473,15 @@ class DocumentEmbedding:
         """
         repo_path = self.get_repo_path(source_info)
         cache_name = source_info.type if source_info.type != "code" else ""
+        if self._manifest_path:
+            full_git_repo_path = f"{source_info.git_repo}/{self._manifest_path}"
+        else:
+            full_git_repo_path = source_info.git_repo
+
 
         documents, documents_were_in_cache = retrieve_from_cache(
             self._pickle_cache_directory,
-            source_info.git_repo,
+            full_git_repo_path,
             source_info.ref,
             documents_name=cache_name,
         )
@@ -487,7 +492,7 @@ class DocumentEmbedding:
         with repo_lock:
             documents, documents_were_in_cache = retrieve_from_cache(
                 self._pickle_cache_directory,
-                source_info.git_repo,
+                full_git_repo_path,
                 source_info.ref,
                 documents_name=cache_name,
             )
@@ -516,7 +521,7 @@ class DocumentEmbedding:
             logger.info("Collected documents for '%s', Document count: %d", repo_path, len(documents))
             save_to_cache(
                 self._pickle_cache_directory,
-                source_info.git_repo,
+                full_git_repo_path,
                 source_info.ref,
                 documents,
                 documents_name=cache_name,
@@ -544,9 +549,14 @@ class DocumentEmbedding:
             Returns a list of documents collected from the source document info.
         """
         repo_path = self.get_repo_path(source_info)
+        if self._manifest_path:
+            full_git_repo_path = f"{source_info.git_repo}/{self._manifest_path}"
+        else:
+            full_git_repo_path = source_info.git_repo
+
         cache_name = source_info.type if source_info.type != "code" else ""
         documents, documents_were_in_cache = retrieve_from_cache(self._pickle_cache_directory,
-                                                                 source_info.git_repo, source_info.ref,
+                                                                 full_git_repo_path, source_info.ref,
                                                                  documents_name=cache_name)
         if documents_were_in_cache or len(documents) > 0:
             return documents
@@ -559,7 +569,7 @@ class DocumentEmbedding:
         with repo_lock:
             # Re-check cache — another thread may have populated it while we waited.
             documents, documents_were_in_cache = retrieve_from_cache(self._pickle_cache_directory,
-                                                                     source_info.git_repo, source_info.ref,
+                                                                     full_git_repo_path, source_info.ref,
                                                                      documents_name=cache_name)
             if documents_were_in_cache or len(documents) > 0:
                 return documents
@@ -578,7 +588,7 @@ class DocumentEmbedding:
             documents = loader.load()
 
             logger.info("Collected documents for '%s', Document count: %d", repo_path, len(documents))
-            save_to_cache(self._pickle_cache_directory, source_info.git_repo, source_info.ref, documents,
+            save_to_cache(self._pickle_cache_directory, full_git_repo_path, source_info.ref, documents,
                           documents_name=cache_name)
             return documents
 

--- a/src/exploit_iq_commons/utils/document_embedding.py
+++ b/src/exploit_iq_commons/utils/document_embedding.py
@@ -39,6 +39,7 @@ from langchain_core.document_loaders.blob_loaders import Blob
 from exploit_iq_commons.data_models.input import SourceDocumentsInfo
 from exploit_iq_commons.utils.data_utils import retrieve_from_cache, save_to_cache, DEFAULT_PICKLE_CACHE_DIRECTORY, DEFAULT_GIT_DIRECTORY, \
     VDB_DIRECTORY, PathLike
+from exploit_iq_commons.utils.dep_tree import Ecosystem
 from exploit_iq_commons.utils.go_segmenters_with_methods import GoSegmenterWithMethods
 from exploit_iq_commons.utils.python_segmenters_with_classes_methods import PythonSegmenterWithClassesMethods
 from exploit_iq_commons.utils.java_segmenters_with_methods import JavaSegmenterWithMethods
@@ -291,7 +292,8 @@ class DocumentEmbedding:
 
     def __init__(self, *, embedding: "Embeddings", vdb_directory: PathLike = VDB_DIRECTORY,
                  git_directory: PathLike = DEFAULT_GIT_DIRECTORY, chunk_size: int = 800, chunk_overlap: int = 160,
-                 pickle_cache_directory: PathLike = DEFAULT_PICKLE_CACHE_DIRECTORY):
+                 pickle_cache_directory: PathLike = DEFAULT_PICKLE_CACHE_DIRECTORY, ecosystem: Ecosystem | None = None,
+                 manifest_path: str | None = None):
         """
         Create a new DocumentEmbedding instance.
 
@@ -317,6 +319,8 @@ class DocumentEmbedding:
         self._chunk_size = chunk_size
         self._chunk_overlap = chunk_overlap
         self._pickle_cache_directory = Path(pickle_cache_directory)
+        self._ecosystem = ecosystem
+        self._manifest_path = manifest_path
 
     @property
     def embedding(self):
@@ -559,7 +563,9 @@ class DocumentEmbedding:
                                               clone_url=source_info.git_repo,
                                               ref=source_info.ref,
                                               include=source_info.include,
-                                              exclude=source_info.exclude)
+                                              exclude=source_info.exclude,
+                                              manifest_path=self._manifest_path,
+                                              ecosystem=self._ecosystem)
             blob_parser = ExtendedLanguageParser()
 
             loader = GenericLoader(blob_loader=blob_loader, blob_parser=blob_parser)

--- a/src/exploit_iq_commons/utils/document_embedding.py
+++ b/src/exploit_iq_commons/utils/document_embedding.py
@@ -410,7 +410,7 @@ class DocumentEmbedding:
         """
         return get_repo_path_with_ref(self._git_directory, source_info.git_repo, source_info.ref)
 
-    def clone_and_install_dependencies(self, source_info: SourceDocumentsInfo) -> Path:
+    def clone_and_install_dependencies(self, source_info: SourceDocumentsInfo, manifest_path: str | None, ecosystem: Ecosystem | None) -> Path:
         """
         Clone the repository and install dependencies without document parsing.
 
@@ -440,6 +440,8 @@ class DocumentEmbedding:
                 ref=source_info.ref,
                 include=source_info.include,
                 exclude=source_info.exclude,
+                manifest_path = manifest_path,                
+                ecosystem = ecosystem
             )
             loader.load_repo()
             logger.info("clone_and_install_dependencies completed for '%s' ref='%s'", source_info.git_repo, source_info.ref)

--- a/src/exploit_iq_commons/utils/document_embedding.py
+++ b/src/exploit_iq_commons/utils/document_embedding.py
@@ -293,7 +293,7 @@ class DocumentEmbedding:
     def __init__(self, *, embedding: "Embeddings", vdb_directory: PathLike = VDB_DIRECTORY,
                  git_directory: PathLike = DEFAULT_GIT_DIRECTORY, chunk_size: int = 800, chunk_overlap: int = 160,
                  pickle_cache_directory: PathLike = DEFAULT_PICKLE_CACHE_DIRECTORY, ecosystem: Ecosystem | None = None,
-                 manifest_path: str | None = None):
+                 manifest_relative_path: str | None = None):
         """
         Create a new DocumentEmbedding instance.
 
@@ -313,7 +313,7 @@ class DocumentEmbedding:
             :param pickle_cache_directory:
         ecosystem: Ecosystem
             The ecosystem used within the repo
-        manifest_path: str, optional
+        manifest_relative_path: str, optional
             The path to manifest file within the Git repository
         """
 
@@ -324,7 +324,7 @@ class DocumentEmbedding:
         self._chunk_overlap = chunk_overlap
         self._pickle_cache_directory = Path(pickle_cache_directory)
         self._ecosystem = ecosystem
-        self._manifest_path = manifest_path
+        self._manifest_relative_path = manifest_relative_path
 
     @property
     def embedding(self):
@@ -414,7 +414,7 @@ class DocumentEmbedding:
         """
         return get_repo_path_with_ref(self._git_directory, source_info.git_repo, source_info.ref)
 
-    def clone_and_install_dependencies(self, source_info: SourceDocumentsInfo, manifest_path: str | None, ecosystem: Ecosystem | None) -> Path:
+    def clone_and_install_dependencies(self, source_info: SourceDocumentsInfo, manifest_relative_path: str | None = None, ecosystem: Ecosystem | None = None) -> Path:
         """
         Clone the repository and install dependencies without document parsing.
 
@@ -444,7 +444,7 @@ class DocumentEmbedding:
                 ref=source_info.ref,
                 include=source_info.include,
                 exclude=source_info.exclude,
-                manifest_path = manifest_path,                
+                manifest_relative_path = manifest_relative_path,
                 ecosystem = ecosystem
             )
             loader.load_repo()
@@ -473,8 +473,8 @@ class DocumentEmbedding:
         """
         repo_path = self.get_repo_path(source_info)
         cache_name = source_info.type if source_info.type != "code" else ""
-        if self._manifest_path:
-            full_git_repo_path = f"{source_info.git_repo}/{self._manifest_path}"
+        if self._manifest_relative_path:
+            full_git_repo_path = f"{source_info.git_repo}/{self._manifest_relative_path}"
         else:
             full_git_repo_path = source_info.git_repo
 
@@ -549,8 +549,8 @@ class DocumentEmbedding:
             Returns a list of documents collected from the source document info.
         """
         repo_path = self.get_repo_path(source_info)
-        if self._manifest_path:
-            full_git_repo_path = f"{source_info.git_repo}/{self._manifest_path}"
+        if self._manifest_relative_path:
+            full_git_repo_path = f"{source_info.git_repo}/{self._manifest_relative_path}"
         else:
             full_git_repo_path = source_info.git_repo
 
@@ -580,7 +580,7 @@ class DocumentEmbedding:
                                               ref=source_info.ref,
                                               include=source_info.include,
                                               exclude=source_info.exclude,
-                                              manifest_path=self._manifest_path,
+                                              manifest_relative_path=self._manifest_relative_path,
                                               ecosystem=self._ecosystem)
             blob_parser = ExtendedLanguageParser()
 

--- a/src/exploit_iq_commons/utils/document_embedding.py
+++ b/src/exploit_iq_commons/utils/document_embedding.py
@@ -311,6 +311,10 @@ class DocumentEmbedding:
         chunk_overlap : int, optional
             Overlap between chunks, by default 200
             :param pickle_cache_directory:
+        ecosystem: Ecosystem
+            The ecosystem used within the repo
+        manifest_path: str, optional
+            The path to manifest file within the Git repository
         """
 
         self._embedding = embedding

--- a/src/exploit_iq_commons/utils/functions_parsers/lang_functions_parsers_factory.py
+++ b/src/exploit_iq_commons/utils/functions_parsers/lang_functions_parsers_factory.py
@@ -28,8 +28,7 @@ def get_language_function_parser(ecosystem: Ecosystem, tree: DependencyTree | No
     :param ecosystem: the desired programming language parser.
     :param tree: the dependency tree for the ecosystem, can be None.
     :return:
-    The right language functions parser associated to the ecosystem, if not exists, return ABC parent that
-     doesn't do anything
+    The right language functions parser associated to the ecosystem, if not exists, throw an NotImplementedError
     """
     if ecosystem == Ecosystem.GO:
         return GoLanguageFunctionsParser()
@@ -48,4 +47,4 @@ def get_language_function_parser(ecosystem: Ecosystem, tree: DependencyTree | No
     elif ecosystem == Ecosystem.JAVA:
         return JavaLanguageFunctionsParser()
     else:
-        return LanguageFunctionsParser()
+        raise NotImplementedError(f"Language functions parser for {ecosystem} not implemented.")

--- a/src/exploit_iq_commons/utils/git_utils.py
+++ b/src/exploit_iq_commons/utils/git_utils.py
@@ -19,6 +19,10 @@ from pathlib import Path
 from pathlib import PurePath
 
 from git import Repo
+from exploit_iq_commons.logging.loggers_factory import LoggingFactory
+
+
+logger = LoggingFactory.get_agent_logger(__name__)
 
 
 def sanitize_git_url_for_path(git_url: str) -> str:
@@ -106,3 +110,20 @@ def get_repo_from_path(base_dir: str, git_repo: str = ".git") -> Repo:
             raise ValueError(f"Invalid Git repository: {repo_path}") from e
     else:
         raise ValueError(f"Path {repo_path} does not exist")
+
+def resolve_path_to_manifest(git_repo_path: Path, manifest_path: str | None = None) -> Path:
+    """Resolve the directory containing the manifest within a Git repository.
+    If ``manifest_path`` is provided, it is treated as a path relative to
+    ``git_repo_path``. Otherwise, the repository root is used.
+    Args:
+        git_repo_path: Root path of the cloned Git repository.
+        manifest_path: Optional relative path to the manifest directory within the repo.
+    Returns:
+        Absolute path to the manifest directory.
+    """
+    if manifest_path:
+        logger.debug(f"Appending git repo manifest path {git_repo_path} with: {manifest_path}")
+        path_to_manifest = git_repo_path.joinpath(manifest_path)
+    else:
+        path_to_manifest = git_repo_path
+    return path_to_manifest

--- a/src/exploit_iq_commons/utils/git_utils.py
+++ b/src/exploit_iq_commons/utils/git_utils.py
@@ -111,19 +111,19 @@ def get_repo_from_path(base_dir: str, git_repo: str = ".git") -> Repo:
     else:
         raise ValueError(f"Path {repo_path} does not exist")
 
-def resolve_path_to_manifest(git_repo_path: Path, manifest_path: str | None = None) -> Path:
+def resolve_path_to_manifest(git_repo_path: Path, manifest_relative_path: str | None = None) -> Path:
     """Resolve the directory containing the manifest within a Git repository.
-    If ``manifest_path`` is provided, it is treated as a path relative to
+    If ``manifest_relative_path`` is provided, it is treated as a path relative to
     ``git_repo_path``. Otherwise, the repository root is used.
     Args:
         git_repo_path: Root path of the cloned Git repository.
-        manifest_path: Optional relative path to the manifest directory within the repo.
+        manifest_relative_path: Optional relative path to the manifest directory within the repo.
     Returns:
         Absolute path to the manifest directory.
     """
-    if manifest_path:
-        logger.debug(f"Appending git repo manifest path {git_repo_path} with: {manifest_path}")
-        path_to_manifest = git_repo_path.joinpath(manifest_path)
+    if manifest_relative_path:
+        logger.debug(f"Appending git repo manifest path {git_repo_path} with: {manifest_relative_path}")
+        path_to_manifest = git_repo_path.joinpath(manifest_relative_path)
     else:
         path_to_manifest = git_repo_path
     return path_to_manifest

--- a/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
+++ b/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
@@ -121,7 +121,7 @@ def _release_repo_data(repo_data: _JavaRepoData) -> None:
 def _get_or_create_repo_data(documents: List[Document],
                              code_source_info: SourceDocumentsInfo,
                              language_parser, 
-                             manifest_path: str | None = None) -> _JavaRepoData:
+                             manifest_relative_path: str | None = None) -> _JavaRepoData:
     """Get or create shared repo-level data for the given (git_repo, ref).
 
     Thread-safe: uses a lock to prevent duplicate creation.  In practice,
@@ -129,8 +129,8 @@ def _get_or_create_repo_data(documents: List[Document],
     repo_lock in _build_or_get_cached, but the lock here provides defense-in-depth.
     """
 
-    if manifest_path:
-        full_git_repo_path = f"{code_source_info.git_repo}/{manifest_path}"
+    if manifest_relative_path:
+        full_git_repo_path = f"{code_source_info.git_repo}/{manifest_relative_path}"
     else:
         full_git_repo_path = code_source_info.git_repo
     key = (full_git_repo_path, code_source_info.ref)
@@ -284,7 +284,8 @@ class JavaChainOfCallsRetriever(ChainOfCallsRetrieverBase):
                  manifest_path: Path,
                  query: str,
                  code_source_info: SourceDocumentsInfo,
-                 uber_jar_file_threshold: int):
+                 uber_jar_file_threshold: int,
+                 manifest_relative_path: str):
         """
         :param documents:
         List of documents containing the functions/methods and classes/types of the application code +
@@ -323,7 +324,7 @@ class JavaChainOfCallsRetriever(ChainOfCallsRetrieverBase):
         # same (git_repo, ref) share one _JavaRepoData instance, eliminating
         # duplicate multi-GB data structures in memory.
         logger.debug("Chain of Calls Retriever - getting or creating shared repo data")
-        self._repo_data = _get_or_create_repo_data(documents, code_source_info, self.language_parser, manifest_path)
+        self._repo_data = _get_or_create_repo_data(documents, code_source_info, self.language_parser, manifest_relative_path=manifest_relative_path)
 
         # Set direct attribute references to shared repo data for backward
         # compatibility — all existing code reads self.xxx and works unchanged.

--- a/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
+++ b/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
@@ -121,7 +121,7 @@ def _release_repo_data(repo_data: _JavaRepoData) -> None:
 def _get_or_create_repo_data(documents: List[Document],
                              code_source_info: SourceDocumentsInfo,
                              language_parser, 
-                             manifest_path: str) -> _JavaRepoData:
+                             manifest_path: str | None = None) -> _JavaRepoData:
     """Get or create shared repo-level data for the given (git_repo, ref).
 
     Thread-safe: uses a lock to prevent duplicate creation.  In practice,

--- a/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
+++ b/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
@@ -128,12 +128,12 @@ def _get_or_create_repo_data(documents: List[Document],
     concurrent calls for the same key are already serialized by the upstream
     repo_lock in _build_or_get_cached, but the lock here provides defense-in-depth.
     """
-    key = (code_source_info.git_repo, code_source_info.ref)
     logger.debug("_get_or_create_repo_data - looking up key %s", key)
     if manifest_path:
         full_git_repo_path = f"{code_source_info.git_repo}/{manifest_path}"
     else:
         full_git_repo_path = code_source_info.git_repo
+    key = (full_git_repo_path, code_source_info.ref)
 
 
     # Fast path: already cached

--- a/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
+++ b/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
@@ -120,7 +120,8 @@ def _release_repo_data(repo_data: _JavaRepoData) -> None:
 
 def _get_or_create_repo_data(documents: List[Document],
                              code_source_info: SourceDocumentsInfo,
-                             language_parser) -> _JavaRepoData:
+                             language_parser, 
+                             manifest_path: str) -> _JavaRepoData:
     """Get or create shared repo-level data for the given (git_repo, ref).
 
     Thread-safe: uses a lock to prevent duplicate creation.  In practice,
@@ -129,6 +130,11 @@ def _get_or_create_repo_data(documents: List[Document],
     """
     key = (code_source_info.git_repo, code_source_info.ref)
     logger.debug("_get_or_create_repo_data - looking up key %s", key)
+    if manifest_path:
+        full_git_repo_path = f"{code_source_info.git_repo}/{manifest_path}"
+    else:
+        full_git_repo_path = code_source_info.git_repo
+
 
     # Fast path: already cached
     with _repo_data_cache_lock:
@@ -145,11 +151,11 @@ def _get_or_create_repo_data(documents: List[Document],
 
     logger.debug("_get_or_create_repo_data - loading pickle sub-caches")
     documents_of_functions_raw, exist_fn = retrieve_from_cache(
-        DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref, "documents_of_functions")
+        DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref, "documents_of_functions")
     documents_of_types, exist_ty = retrieve_from_cache(
-        DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref, "documents_of_types")
+        DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref, "documents_of_types")
     documents_of_full_sources, exist_fs = retrieve_from_cache(
-        DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref, "documents_of_full_sources")
+        DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref, "documents_of_full_sources")
 
     need_fn = not exist_fn
     need_ty = not exist_ty
@@ -183,46 +189,46 @@ def _get_or_create_repo_data(documents: List[Document],
         if need_fn:
             documents_of_functions_raw = fn_list
             logger.debug("_get_or_create_repo_data - saving documents_of_functions to pickle (%d docs)", len(fn_list))
-            save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref,
+            save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref,
                           documents_of_functions_raw, "documents_of_functions")
         if need_ty:
             documents_of_types = ty_list
             logger.debug("_get_or_create_repo_data - saving documents_of_types to pickle (%d docs)", len(ty_list))
-            save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref,
+            save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref,
                           documents_of_types, "documents_of_types")
         if need_fs:
             documents_of_full_sources = full_dict
             logger.debug("_get_or_create_repo_data - saving documents_of_full_sources to pickle (%d docs)", len(full_dict))
-            save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref,
+            save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref,
                           documents_of_full_sources, "documents_of_full_sources")
 
     type_inheritance, exist = retrieve_from_cache(
-        DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref, "type_inheritance")
+        DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref, "type_inheritance")
     if not exist:
         logger.debug("_get_or_create_repo_data - building type_inheritance from documents_of_full_sources")
         type_inheritance = create_inheritance_map(documents_of_full_sources.values())
-        save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref,
+        save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref,
                       type_inheritance, "type_inheritance")
     else:
         logger.debug("_get_or_create_repo_data - type_inheritance loaded from pickle")
 
     types_classes_fields_mapping, exist = retrieve_from_cache(
-        DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref, "types_classes_fields_mapping")
+        DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref, "types_classes_fields_mapping")
     if not exist:
         logger.debug("_get_or_create_repo_data - building types_classes_fields_mapping")
         types_classes_fields_mapping = language_parser.parse_all_type_struct_class_to_fields(
             documents_of_types, type_inheritance)
-        save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref,
+        save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref,
                       types_classes_fields_mapping, "types_classes_fields_mapping")
     else:
         logger.debug("_get_or_create_repo_data - types_classes_fields_mapping loaded from pickle")
 
     functions_local_variables_index, exist = retrieve_from_cache(
-        DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref, "functions_local_variables_index")
+        DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref, "functions_local_variables_index")
     if not exist:
         logger.debug("_get_or_create_repo_data - building functions_local_variables_index")
         functions_local_variables_index = language_parser.create_map_of_local_vars(documents_of_functions_raw)
-        save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, code_source_info.git_repo, code_source_info.ref,
+        save_to_cache(DEFAULT_PICKLE_CACHE_DIRECTORY, full_git_repo_path, code_source_info.ref,
                       functions_local_variables_index, "functions_local_variables_index")
     else:
         logger.debug("_get_or_create_repo_data - functions_local_variables_index loaded from pickle")
@@ -317,7 +323,7 @@ class JavaChainOfCallsRetriever(ChainOfCallsRetrieverBase):
         # same (git_repo, ref) share one _JavaRepoData instance, eliminating
         # duplicate multi-GB data structures in memory.
         logger.debug("Chain of Calls Retriever - getting or creating shared repo data")
-        self._repo_data = _get_or_create_repo_data(documents, code_source_info, self.language_parser)
+        self._repo_data = _get_or_create_repo_data(documents, code_source_info, self.language_parser, manifest_path)
 
         # Set direct attribute references to shared repo data for backward
         # compatibility — all existing code reads self.xxx and works unchanged.

--- a/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
+++ b/src/exploit_iq_commons/utils/java_chain_of_calls_retriever.py
@@ -128,13 +128,13 @@ def _get_or_create_repo_data(documents: List[Document],
     concurrent calls for the same key are already serialized by the upstream
     repo_lock in _build_or_get_cached, but the lock here provides defense-in-depth.
     """
-    logger.debug("_get_or_create_repo_data - looking up key %s", key)
+
     if manifest_path:
         full_git_repo_path = f"{code_source_info.git_repo}/{manifest_path}"
     else:
         full_git_repo_path = code_source_info.git_repo
     key = (full_git_repo_path, code_source_info.ref)
-
+    logger.debug("_get_or_create_repo_data - looking up key %s", key)
 
     # Fast path: already cached
     with _repo_data_cache_lock:

--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -253,7 +253,7 @@ class SourceCodeGitLoader(BlobLoader):
 
         logger.info("Loaded Git repository at path: '%s' @ '%s'", self.repo_path, self.ref)
         TransitiveCodeSearcher.download_dependencies(
-            self.repo_path, 
+            self.repo_path,
             manifest_path= self._manifest_path,
             the_ecosystem=self._ecosystem)
         self._repo = repo

--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -108,6 +108,10 @@ class SourceCodeGitLoader(BlobLoader):
             A list of file patterns to exclude. Uses the glob syntax, by default None
             :param manifest_path:
             :param ecosystem:
+        manifest_path: str | None, optional
+            The path to manifest file within the Git repository
+        ecosystem: str | None, optional
+            The ecosystem used within the repo
 
         Credential for private repository authentication is read from the current
         async context (set via ``credential_context()`` in cve_generate_vdbs).

--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -89,7 +89,7 @@ class SourceCodeGitLoader(BlobLoader):
         ref: typing.Optional[str] = "main",
         include: typing.Optional[typing.Iterable[str]] = None,
         exclude: typing.Optional[typing.Iterable[str]] = None,
-        manifest_path: str | None = None,
+        manifest_relative_path: str | None = None,
         ecosystem: Ecosystem | None = None):
         """
         Initialize the Git loader.
@@ -106,9 +106,9 @@ class SourceCodeGitLoader(BlobLoader):
             A list of file patterns to include. Uses the glob syntax, by default None
         exclude : typing.Optional[typing.Iterable[str]], optional
             A list of file patterns to exclude. Uses the glob syntax, by default None
-            :param manifest_path:
+            :param manifest_relative_path:
             :param ecosystem:
-        manifest_path: str | None, optional
+        manifest_relative_path: str | None, optional
             The path to manifest file within the Git repository
         ecosystem: str | None, optional
             The ecosystem used within the repo
@@ -118,7 +118,7 @@ class SourceCodeGitLoader(BlobLoader):
         """
 
         self.repo_path = Path(repo_path)
-        self._manifest_path = manifest_path
+        self._manifest_relative_path = manifest_relative_path
         self._ecosystem = ecosystem
         self.clone_url = clone_url
         self.ref = ref
@@ -258,7 +258,7 @@ class SourceCodeGitLoader(BlobLoader):
         logger.info("Loaded Git repository at path: '%s' @ '%s'", self.repo_path, self.ref)
         TransitiveCodeSearcher.download_dependencies(
             self.repo_path,
-            manifest_path= self._manifest_path,
+            manifest_relative_path= self._manifest_relative_path,
             the_ecosystem=self._ecosystem)
         self._repo = repo
 

--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -27,6 +27,8 @@ from langchain_community.document_loaders.blob_loaders.schema import BlobLoader
 from langchain_core.document_loaders.blob_loaders import Blob
 from tqdm import tqdm
 
+
+
 from exploit_iq_commons.logging.loggers_factory import LoggingFactory
 from exploit_iq_commons.utils.credential_client import (
     AES_256_KEY_SIZE_BYTES,
@@ -35,7 +37,8 @@ from exploit_iq_commons.utils.credential_client import (
     _credential_id_ctx,
     fetch_and_decrypt_credential,
 )
-from exploit_iq_commons.utils.dep_tree import INSTALLED_PACKAGES_FILE, TRANSITIVE_ENV_NAME
+
+from exploit_iq_commons.utils.dep_tree import INSTALLED_PACKAGES_FILE, TRANSITIVE_ENV_NAME, Ecosystem
 from exploit_iq_commons.utils.transitive_code_searcher_tool import (
     TransitiveCodeSearcher,
 )
@@ -86,7 +89,8 @@ class SourceCodeGitLoader(BlobLoader):
         ref: typing.Optional[str] = "main",
         include: typing.Optional[typing.Iterable[str]] = None,
         exclude: typing.Optional[typing.Iterable[str]] = None,
-    ):
+        manifest_path: str | None = None,
+        ecosystem: Ecosystem | None = None):
         """
         Initialize the Git loader.
 
@@ -102,12 +106,16 @@ class SourceCodeGitLoader(BlobLoader):
             A list of file patterns to include. Uses the glob syntax, by default None
         exclude : typing.Optional[typing.Iterable[str]], optional
             A list of file patterns to exclude. Uses the glob syntax, by default None
+            :param manifest_path:
+            :param ecosystem:
 
         Credential for private repository authentication is read from the current
         async context (set via ``credential_context()`` in cve_generate_vdbs).
         """
 
         self.repo_path = Path(repo_path)
+        self._manifest_path = manifest_path
+        self._ecosystem = ecosystem
         self.clone_url = clone_url
         self.ref = ref
 
@@ -244,7 +252,10 @@ class SourceCodeGitLoader(BlobLoader):
         repo.git.checkout(self.ref, "--force")
 
         logger.info("Loaded Git repository at path: '%s' @ '%s'", self.repo_path, self.ref)
-        TransitiveCodeSearcher.download_dependencies(self.repo_path)
+        TransitiveCodeSearcher.download_dependencies(
+            self.repo_path, 
+            manifest_path= self._manifest_path,
+            the_ecosystem=self._ecosystem)
         self._repo = repo
 
         return repo

--- a/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
+++ b/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
@@ -29,12 +29,12 @@ from exploit_iq_commons.logging.loggers_factory import LoggingFactory, MULTI_LIN
 
 logger = LoggingFactory.get_agent_logger(f"morpheus.{__name__}")
 
-def determine_manifest_name_by_ecosystem(the_ecosystem):
-    for manifest_name, ecosystem in MANIFESTS_TO_ECOSYSTEMS.items():
-        if ecosystem == the_ecosystem:
-            logger.debug(f"Manifest found for ecosystem '{the_ecosystem}': '{manifest_name}'")
-            return manifest_name
-
+def determine_manifest_name_by_ecosystem(the_ecosystem:Ecosystem | None = None):
+    if the_ecosystem:
+        for manifest_name, ecosystem in MANIFESTS_TO_ECOSYSTEMS.items():
+            if ecosystem == the_ecosystem:
+                logger.debug(f"Manifest found for ecosystem '{the_ecosystem}': '{manifest_name}'")
+                return manifest_name
     return None
 
 

--- a/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
+++ b/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
@@ -54,13 +54,13 @@ class TransitiveCodeSearcher:
         self.chain_of_calls_retriever = chain_of_calls_retriever
 
     @staticmethod
-    def download_dependencies(git_repo_path: Path, manifest_path: str | None = None, the_ecosystem: Ecosystem | None = None) -> bool:
+    def download_dependencies(git_repo_path: Path, manifest_relative_path: str | None = None, the_ecosystem: Ecosystem | None = None) -> bool:
         """ Download all dependencies according to manifest file in the Git repository
         Parameters
         ----------
         git_repo_path : Path
         Git repository path to fetch the application manifests from
-        manifest_path: str, optional
+        manifest_relative_path: str, optional
         path to manifest file within the Git repository
         the_ecosystem: Ecosystem, optional
         The ecosystem used within the repo
@@ -69,7 +69,7 @@ class TransitiveCodeSearcher:
         Returns whether dependencies were downloaded or not.
         """
         path_to_manifest: Path
-        path_to_manifest = resolve_path_to_manifest(git_repo_path, manifest_path)
+        path_to_manifest = resolve_path_to_manifest(git_repo_path, manifest_relative_path)
         #     If ecosystem is supplied in input, then override default of first found ecosystem manifest in the repo.
 
         manifest_file_for_ecosystem = determine_manifest_name_by_ecosystem(the_ecosystem)

--- a/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
+++ b/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
@@ -19,6 +19,8 @@ from langchain.docstore.document import Document
 
 from exploit_iq_commons.utils.chain_of_calls_retriever_base import ChainOfCallsRetrieverBase
 from exploit_iq_commons.utils.dep_tree import (
+    MANIFESTS_TO_ECOSYSTEMS,
+    Ecosystem,
     detect_ecosystem,
     get_dependency_tree_builder,
 )
@@ -26,6 +28,14 @@ from exploit_iq_commons.utils.dep_tree import (
 from exploit_iq_commons.logging.loggers_factory import LoggingFactory, MULTI_LINE_MESSAGE_TRUE
 
 logger = LoggingFactory.get_agent_logger(f"morpheus.{__name__}")
+
+def determine_manifest_name_by_ecosystem(the_ecosystem):
+    for manifest_name, ecosystem in MANIFESTS_TO_ECOSYSTEMS.items():
+        if ecosystem == the_ecosystem:
+            logger.debug(f"Manifest found for ecosystem '{the_ecosystem}': '{manifest_name}'")
+            return manifest_name
+
+    return None
 
 
 class TransitiveCodeSearcher:
@@ -43,16 +53,36 @@ class TransitiveCodeSearcher:
         self.chain_of_calls_retriever = chain_of_calls_retriever
 
     @staticmethod
-    def download_dependencies(git_repo_path: Path) -> bool:
+    def download_dependencies(git_repo_path: Path, manifest_path: str | None = None, the_ecosystem: Ecosystem | None = None) -> bool:
         """ Download all dependencies according to manifest file in the Git repository
         Parameters
         ----------
         git_repo_path : Path
         Git repository path to fetch the application manifests from
+        manifest_path: str
+        path to manifest file within the Git repository
 
         Returns whether dependencies were downloaded or not.
+        :param the_ecosystem:
+        :param git_repo_path:
+        :param manifest_path:
         """
-        ecosystem = detect_ecosystem(git_repo_path)
+        path_to_manifest: Path
+        if manifest_path:
+            path_to_manifest = git_repo_path.joinpath(manifest_path)
+            logger.info(f"manifest_path field supplied in request payload, overriding default value of "
+                        f"root directory of repository."
+                        f" relative manifest_path value => {manifest_path}, path_to_manifest=>{path_to_manifest}")
+        else:
+            path_to_manifest = git_repo_path
+        #     If ecosystem is supplied in input, then override default of first found ecosystem manifest in the repo.
+        if the_ecosystem and os.path.isfile(path_to_manifest / determine_manifest_name_by_ecosystem(the_ecosystem)):
+            logger.info(f"Setting ecosystem to user-provided value: {the_ecosystem}")
+            ecosystem = the_ecosystem
+            logger.info(f"Ecosystem field supplied in request payload, ecosystem value => {ecosystem}")
+        else:
+            ecosystem = detect_ecosystem(git_repo_path)
+            logger.info(f"Detected ecosystem is {ecosystem}")
         if ecosystem is None:
             logger.info(f"Didn't find manifest to install, skipping.. {git_repo_path}")
             return False
@@ -61,8 +91,9 @@ class TransitiveCodeSearcher:
             logger.info(f"Started installing packages for {ecosystem.value}")
             tree_builder = get_dependency_tree_builder(ecosystem)
             tree_builder.install_dependencies(git_repo_path)
-            with open(os.path.join(git_repo_path, 'ecosystem_data.txt'), 'w') as file:
-                file.write(ecosystem.name)
+            if not the_ecosystem:
+                with open(os.path.join(git_repo_path, 'ecosystem_data.txt'), 'w') as file:
+                    file.write(ecosystem.name)
             logger.info(f"Finished installing packages for {ecosystem}")
             return True
         except NotImplementedError as err:

--- a/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
+++ b/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
@@ -26,6 +26,7 @@ from exploit_iq_commons.utils.dep_tree import (
 )
 
 from exploit_iq_commons.logging.loggers_factory import LoggingFactory, MULTI_LINE_MESSAGE_TRUE
+from exploit_iq_commons.utils.git_utils import resolve_path_to_manifest
 
 logger = LoggingFactory.get_agent_logger(f"morpheus.{__name__}")
 
@@ -68,13 +69,7 @@ class TransitiveCodeSearcher:
         Returns whether dependencies were downloaded or not.
         """
         path_to_manifest: Path
-        if manifest_path:
-            path_to_manifest = git_repo_path.joinpath(manifest_path)
-            logger.info(f"manifest_path field supplied in request payload, overriding default value of "
-                        f"root directory of repository."
-                        f" relative manifest_path value => {manifest_path}, path_to_manifest=>{path_to_manifest}")
-        else:
-            path_to_manifest = git_repo_path
+        path_to_manifest = resolve_path_to_manifest(git_repo_path, manifest_path)
         #     If ecosystem is supplied in input, then override default of first found ecosystem manifest in the repo.
 
         manifest_file_for_ecosystem = determine_manifest_name_by_ecosystem(the_ecosystem)

--- a/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
+++ b/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
@@ -59,13 +59,13 @@ class TransitiveCodeSearcher:
         ----------
         git_repo_path : Path
         Git repository path to fetch the application manifests from
-        manifest_path: str
+        manifest_path: str, optional
         path to manifest file within the Git repository
+        the_ecosystem: Ecosystem, optional
+        The ecosystem used within the repo
+
 
         Returns whether dependencies were downloaded or not.
-        :param the_ecosystem:
-        :param git_repo_path:
-        :param manifest_path:
         """
         path_to_manifest: Path
         if manifest_path:

--- a/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
+++ b/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
@@ -81,18 +81,18 @@ class TransitiveCodeSearcher:
             ecosystem = the_ecosystem
             logger.info(f"Ecosystem field supplied in request payload, ecosystem value => {ecosystem}")
         else:
-            ecosystem = detect_ecosystem(git_repo_path)
+            ecosystem = detect_ecosystem(path_to_manifest)
             logger.info(f"Detected ecosystem is {ecosystem}")
         if ecosystem is None:
-            logger.info(f"Didn't find manifest to install, skipping.. {git_repo_path}")
+            logger.info(f"Didn't find manifest to install, skipping.. {path_to_manifest}")
             return False
 
         try:
             logger.info(f"Started installing packages for {ecosystem.value}")
             tree_builder = get_dependency_tree_builder(ecosystem)
-            tree_builder.install_dependencies(git_repo_path)
+            tree_builder.install_dependencies(path_to_manifest)
             if not the_ecosystem:
-                with open(os.path.join(git_repo_path, 'ecosystem_data.txt'), 'w') as file:
+                with open(os.path.join(path_to_manifest, 'ecosystem_data.txt'), 'w') as file:
                     file.write(ecosystem.name)
             logger.info(f"Finished installing packages for {ecosystem}")
             return True

--- a/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
+++ b/src/exploit_iq_commons/utils/transitive_code_searcher_tool.py
@@ -76,7 +76,9 @@ class TransitiveCodeSearcher:
         else:
             path_to_manifest = git_repo_path
         #     If ecosystem is supplied in input, then override default of first found ecosystem manifest in the repo.
-        if the_ecosystem and os.path.isfile(path_to_manifest / determine_manifest_name_by_ecosystem(the_ecosystem)):
+
+        manifest_file_for_ecosystem = determine_manifest_name_by_ecosystem(the_ecosystem)
+        if manifest_file_for_ecosystem and the_ecosystem and os.path.isfile(path_to_manifest / manifest_file_for_ecosystem):
             logger.info(f"Setting ecosystem to user-provided value: {the_ecosystem}")
             ecosystem = the_ecosystem
             logger.info(f"Ecosystem field supplied in request payload, ecosystem value => {ecosystem}")

--- a/src/vuln_analysis/functions/cve_clone_and_deps.py
+++ b/src/vuln_analysis/functions/cve_clone_and_deps.py
@@ -112,8 +112,12 @@ async def clone_and_deps(config: CVECloneAndDepsConfig, builder: Builder):
                 code_sources = [si for si in source_infos if si.type == "code"]
                 for si in code_sources:
                     try:
-                        # TODO: netanel: Need a way to determine this is 'single repo' and not sbom..
-                        embedder.clone_and_install_dependencies(si, message.image.manifest_path, message.image.ecosystem)
+                        manifest_path = None
+                        ecosystem = None
+                        if message.image.analysis_type == 'source':
+                            manifest_path = message.image.manifest_path
+                            ecosystem = message.image.ecosystem
+                        embedder.clone_and_install_dependencies(si, manifest_path, ecosystem)
                     except Exception as e:
                         logger.warning(
                             "Error cloning/installing for source %s: %s",

--- a/src/vuln_analysis/functions/cve_clone_and_deps.py
+++ b/src/vuln_analysis/functions/cve_clone_and_deps.py
@@ -112,7 +112,8 @@ async def clone_and_deps(config: CVECloneAndDepsConfig, builder: Builder):
                 code_sources = [si for si in source_infos if si.type == "code"]
                 for si in code_sources:
                     try:
-                        embedder.clone_and_install_dependencies(si)
+                        # TODO: netanel: Need a way to determine this is 'single repo' and not sbom..
+                        embedder.clone_and_install_dependencies(si, message.image.manifest_path, message.image.ecosystem)
                     except Exception as e:
                         logger.warning(
                             "Error cloning/installing for source %s: %s",

--- a/src/vuln_analysis/functions/cve_clone_and_deps.py
+++ b/src/vuln_analysis/functions/cve_clone_and_deps.py
@@ -114,7 +114,7 @@ async def clone_and_deps(config: CVECloneAndDepsConfig, builder: Builder):
                     try:
                         manifest_path = None
                         ecosystem = None
-                        if message.image.analysis_type == 'source':
+                        if message.image.analysis_type == AnalysisType.SOURCE:
                             manifest_path = message.image.manifest_path
                             ecosystem = message.image.ecosystem
                         embedder.clone_and_install_dependencies(si, manifest_path, ecosystem)

--- a/src/vuln_analysis/functions/cve_clone_and_deps.py
+++ b/src/vuln_analysis/functions/cve_clone_and_deps.py
@@ -112,12 +112,12 @@ async def clone_and_deps(config: CVECloneAndDepsConfig, builder: Builder):
                 code_sources = [si for si in source_infos if si.type == "code"]
                 for si in code_sources:
                     try:
-                        manifest_path = None
+                        manifest_relative_path = None
                         ecosystem = None
                         if message.image.analysis_type == AnalysisType.SOURCE:
-                            manifest_path = message.image.manifest_path
+                            manifest_relative_path = message.image.manifest_path
                             ecosystem = message.image.ecosystem
-                        embedder.clone_and_install_dependencies(si, manifest_path, ecosystem)
+                        embedder.clone_and_install_dependencies(si, manifest_relative_path, ecosystem)
                     except Exception as e:
                         logger.warning(
                             "Error cloning/installing for source %s: %s",

--- a/src/vuln_analysis/functions/cve_generate_vdbs.py
+++ b/src/vuln_analysis/functions/cve_generate_vdbs.py
@@ -29,7 +29,7 @@ from pydantic import Field
 from exploit_iq_commons.data_models.common import AnalysisType
 from exploit_iq_commons.logging.loggers_factory import LoggingFactory, trace_id
 from exploit_iq_commons.utils.credential_client import credential_context
-from exploit_iq_commons.utils.dep_tree import detect_ecosystem
+from exploit_iq_commons.utils.dep_tree import Ecosystem, detect_ecosystem
 from vuln_analysis.tools.tool_names import ToolNames
 
 logger = LoggingFactory.get_agent_logger(__name__)
@@ -149,7 +149,9 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
         logger.info("Completed code indexing in %.2f seconds for '%s'", time.time() - indexing_start_time, output_path)
         return True
 
-    def _build_code_index(source_infos: list[SourceDocumentsInfo]) -> Path | None:
+    def _build_code_index(source_infos: list[SourceDocumentsInfo],
+            ecosystem: Ecosystem | None = None,
+            manifest_path: str | None = None) -> Path | None:
         code_index_path: Path | None = None
 
         # Filter to only code sources
@@ -161,7 +163,9 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
             embedder = DocumentEmbedding(embedding=None,
                                          vdb_directory=config.base_vdb_dir,
                                          git_directory=config.base_git_dir,
-                                         pickle_cache_directory=config.base_pickle_dir)
+                                         pickle_cache_directory=config.base_pickle_dir,
+                                         manifest_path=manifest_path,
+                                         ecosystem=ecosystem)
 
             # Determine code index path for either loading from cache or creating new index
             # Need to add support for configurable base path
@@ -203,6 +207,8 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
         base_image = message.image.name
         source_infos = message.image.source_info
         sbom_infos = message.image.sbom_info
+        ecosystem = message.image.ecosystem
+        manifest_path = message.image.manifest_path
         failure_reason = ""
         try:
             trace_id.set(message.scan.id)
@@ -233,7 +239,7 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
                         image = f"{message.image.name}:{message.image.tag}"
                         RPMDependencyManager.get_instance().container_image = image
 
-                    code_index_path = _build_code_index(source_infos)
+                    code_index_path = _build_code_index(source_infos, ecosystem, manifest_path)
 
                     if code_index_path is None:
                         logger.warning(("Failed to generate code index for image '%s'. "

--- a/src/vuln_analysis/functions/cve_generate_vdbs.py
+++ b/src/vuln_analysis/functions/cve_generate_vdbs.py
@@ -164,7 +164,7 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
                                          vdb_directory=config.base_vdb_dir,
                                          git_directory=config.base_git_dir,
                                          pickle_cache_directory=config.base_pickle_dir,
-                                         manifest_path=manifest_path,
+                                         manifest_relative_path=manifest_path,
                                          ecosystem=ecosystem)
 
             # Determine code index path for either loading from cache or creating new index
@@ -203,13 +203,15 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
         vdb_doc_path = None
         code_index_path = None
         ecosystem_detected = True
-
         base_image = message.image.name
         source_infos = message.image.source_info
         sbom_infos = message.image.sbom_info
-        ecosystem = message.image.ecosystem
-        manifest_path = message.image.manifest_path
         failure_reason = ""
+        ecosystem = None
+        manifest_relative_path = None
+        if message.image.analysis_type == AnalysisType.SOURCE:
+            ecosystem = message.image.ecosystem
+            manifest_relative_path = message.image.manifest_path
         try:
             trace_id.set(message.scan.id)
             logger.debug("_arun: received credential_id=%r scan_id=%s", message.credential_id, message.scan.id)
@@ -239,7 +241,7 @@ async def generate_vdb(config: CVEGenerateVDBsToolConfig, builder: Builder):
                         image = f"{message.image.name}:{message.image.tag}"
                         RPMDependencyManager.get_instance().container_image = image
 
-                    code_index_path = _build_code_index(source_infos, ecosystem, manifest_path)
+                    code_index_path = _build_code_index(source_infos, ecosystem, manifest_relative_path)
 
                     if code_index_path is None:
                         logger.warning(("Failed to generate code index for image '%s'. "

--- a/src/vuln_analysis/functions/cve_segmentation.py
+++ b/src/vuln_analysis/functions/cve_segmentation.py
@@ -171,7 +171,7 @@ async def segmentation(config: CVESegmentationConfig, builder: Builder):
 
     def _build_code_index(source_infos: list[SourceDocumentsInfo],
             ecosystem: Ecosystem | None = None,
-            manifest_path: str | None = None) -> Path | None:
+            manifest_relative_path: str | None = None) -> Path | None:
         code_sources = [si for si in source_infos if si.type == "code"]
         if not code_sources:
             return None
@@ -182,7 +182,7 @@ async def segmentation(config: CVESegmentationConfig, builder: Builder):
             git_directory=config.base_git_dir,
             pickle_cache_directory=config.base_pickle_dir,
             ecosystem=ecosystem,
-            manifest_path=manifest_path
+            manifest_relative_path=manifest_relative_path
         )
 
         code_index_path = FullTextSearch.get_index_directory(
@@ -216,8 +216,7 @@ async def segmentation(config: CVESegmentationConfig, builder: Builder):
         code_index_path = None
         failure_reason = ""
         ecosystem = state.input.image.ecosystem
-        manifest_path = state.input.image.manifest_path
-
+        manifest_relative_path = state.input.image.manifest_path
 
         try:
             logger.debug(
@@ -245,7 +244,7 @@ async def segmentation(config: CVESegmentationConfig, builder: Builder):
                     )
 
                 if not config.ignore_code_index:
-                    code_index_path = _build_code_index(source_infos, ecosystem, manifest_path)
+                    code_index_path = _build_code_index(source_infos, ecosystem, manifest_relative_path)
                     if code_index_path is None:
                         logger.warning(
                             "Failed to generate code index for image '%s'",

--- a/src/vuln_analysis/functions/cve_segmentation.py
+++ b/src/vuln_analysis/functions/cve_segmentation.py
@@ -36,6 +36,7 @@ from pydantic import Field
 
 from exploit_iq_commons.logging.loggers_factory import LoggingFactory, trace_id
 from exploit_iq_commons.utils.credential_client import credential_context
+from exploit_iq_commons.utils.dep_tree import Ecosystem
 from vuln_analysis.tools.tool_names import ToolNames
 
 logger = LoggingFactory.get_agent_logger(__name__)
@@ -168,7 +169,9 @@ async def segmentation(config: CVESegmentationConfig, builder: Builder):
         )
         return True
 
-    def _build_code_index(source_infos: list[SourceDocumentsInfo]) -> Path | None:
+    def _build_code_index(source_infos: list[SourceDocumentsInfo],
+            ecosystem: Ecosystem | None = None,
+            manifest_path: str | None = None) -> Path | None:
         code_sources = [si for si in source_infos if si.type == "code"]
         if not code_sources:
             return None
@@ -178,6 +181,8 @@ async def segmentation(config: CVESegmentationConfig, builder: Builder):
             vdb_directory=config.base_vdb_dir,
             git_directory=config.base_git_dir,
             pickle_cache_directory=config.base_pickle_dir,
+            ecosystem=ecosystem,
+            manifest_path=manifest_path
         )
 
         code_index_path = FullTextSearch.get_index_directory(
@@ -210,6 +215,9 @@ async def segmentation(config: CVESegmentationConfig, builder: Builder):
         vdb_doc_path = None
         code_index_path = None
         failure_reason = ""
+        ecosystem = state.input.image.ecosystem
+        manifest_path = state.input.image.manifest_path
+
 
         try:
             logger.debug(
@@ -237,7 +245,7 @@ async def segmentation(config: CVESegmentationConfig, builder: Builder):
                     )
 
                 if not config.ignore_code_index:
-                    code_index_path = _build_code_index(source_infos)
+                    code_index_path = _build_code_index(source_infos, ecosystem, manifest_path)
                     if code_index_path is None:
                         logger.warning(
                             "Failed to generate code index for image '%s'",

--- a/src/vuln_analysis/functions/cve_verify_vuln_package.py
+++ b/src/vuln_analysis/functions/cve_verify_vuln_package.py
@@ -883,10 +883,10 @@ async def cve_verify_vuln_package(config: CVEVerifyVulnPackageConfig, builder: B
         )
         manifest_rel = message.input.image.manifest_path
         analysis_type = message.input.image.analysis_type
-        dep_path = repo_path.joinpath(manifest_rel) if analysis_type == 'source' and manifest_rel else repo_path
+        dep_path = repo_path.joinpath(manifest_rel) if analysis_type == AnalysisType.SOURCE and manifest_rel else repo_path
 
         logger.info("Repo path: %s", repo_path)
-        if analysis_type == 'source' and manifest_rel:
+        if analysis_type == AnalysisType.SOURCE and manifest_rel:
             logger.info("Manifest path: %s (resolved: %s)", manifest_rel, dep_path)
 
         # Parse dependencies using ecosystem-specific matcher

--- a/src/vuln_analysis/functions/cve_verify_vuln_package.py
+++ b/src/vuln_analysis/functions/cve_verify_vuln_package.py
@@ -882,11 +882,11 @@ async def cve_verify_vuln_package(config: CVEVerifyVulnPackageConfig, builder: B
             Path(config.base_git_dir), first_source.git_repo, first_source.ref
         )
         manifest_rel = message.input.image.manifest_path
-        analysys_type = message.input.image.analysis_type
-        dep_path = repo_path.joinpath(manifest_rel) if analysys_type == 'source' and manifest_rel else repo_path
+        analysis_type = message.input.image.analysis_type
+        dep_path = repo_path.joinpath(manifest_rel) if analysis_type == 'source' and manifest_rel else repo_path
 
         logger.info("Repo path: %s", repo_path)
-        if analysys_type == 'source' and manifest_rel:
+        if analysis_type == 'source' and manifest_rel:
             logger.info("Manifest path: %s (resolved: %s)", manifest_rel, dep_path)
 
         # Parse dependencies using ecosystem-specific matcher

--- a/src/vuln_analysis/functions/cve_verify_vuln_package.py
+++ b/src/vuln_analysis/functions/cve_verify_vuln_package.py
@@ -881,13 +881,18 @@ async def cve_verify_vuln_package(config: CVEVerifyVulnPackageConfig, builder: B
         repo_path = get_repo_path_with_ref(
             Path(config.base_git_dir), first_source.git_repo, first_source.ref
         )
+        manifest_rel = message.input.image.manifest_path
+        analysys_type = message.input.image.analysis_type
+        dep_path = repo_path.joinpath(manifest_rel) if analysys_type == 'source' and manifest_rel else repo_path
 
         logger.info("Repo path: %s", repo_path)
+        if analysys_type == 'source' and manifest_rel:
+            logger.info("Manifest path: %s (resolved: %s)", manifest_rel, dep_path)
 
         # Parse dependencies using ecosystem-specific matcher
         try:
             dependencies = matcher.parse_dependencies(
-                repo_path, git_repo=first_source.git_repo, ref=first_source.ref
+                dep_path, git_repo=first_source.git_repo, ref=first_source.ref
             )
             logger.info("Parsed %d packages from lock file", len(dependencies))
         except FileNotFoundError as e:
@@ -909,7 +914,7 @@ async def cve_verify_vuln_package(config: CVEVerifyVulnPackageConfig, builder: B
         system_name = ECOSYSTEM_TO_SYSTEM_NAME.get(ecosystem, ecosystem.value)
 
         # Extract toolchain version for stdlib fallback
-        toolchain_version = _extract_toolchain_version(repo_path, ecosystem)
+        toolchain_version = _extract_toolchain_version(dep_path, ecosystem)
         if toolchain_version:
             logger.info("Detected toolchain version: %s", toolchain_version)
 

--- a/src/vuln_analysis/tools/tests/test_concurrency.py
+++ b/src/vuln_analysis/tools/tests/test_concurrency.py
@@ -321,7 +321,7 @@ async def test_cache_hit_skips_build():
 
     build_count = 0
 
-    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=())):
+    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=()):
         nonlocal build_count
         build_count += 1
         return _make_nonjava_searcher()
@@ -347,7 +347,7 @@ async def test_java_cache_hit_skips_build():
 
     build_count = 0
 
-    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=())):
+    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=()):
         nonlocal build_count
         build_count += 1
         return _make_java_searcher()
@@ -515,7 +515,11 @@ class TestBuildSearcherBaseDirs:
              patch("vuln_analysis.tools.transitive_code_search.DocumentEmbedding") as mock_de:
             mock_get_coc.return_value = MagicMock()
             _build_searcher(si, "pkg,Func", _DEFAULT_THRESHOLD, base_dirs=())
-            mock_de.assert_called_once_with(embedding=None)
+            mock_de.assert_called_once_with(
+                embedding=None,
+                ecosystem=None,
+                manifest_relative_path=None,
+            )
 
     def test_valid_base_dirs_passed_to_document_embedding(self):
         """Two-element tuple should pass git_directory and pickle_cache_directory."""
@@ -528,6 +532,8 @@ class TestBuildSearcherBaseDirs:
                 embedding=None,
                 pickle_cache_directory="/custom/pickle",
                 git_directory="/custom/git",
+                ecosystem=None,
+                manifest_relative_path=None,
             )
 
     def test_single_element_tuple_falls_back_to_defaults(self):
@@ -537,7 +543,11 @@ class TestBuildSearcherBaseDirs:
              patch("vuln_analysis.tools.transitive_code_search.DocumentEmbedding") as mock_de:
             mock_get_coc.return_value = MagicMock()
             _build_searcher(si, "pkg,Func", _DEFAULT_THRESHOLD, base_dirs=("/only/one",))
-            mock_de.assert_called_once_with(embedding=None)
+            mock_de.assert_called_once_with(
+                embedding=None,
+                ecosystem=None,
+                manifest_relative_path=None,
+            )
 
     def test_default_parameter_uses_defaults(self):
         """Omitting base_dirs entirely should use defaults."""
@@ -546,7 +556,11 @@ class TestBuildSearcherBaseDirs:
              patch("vuln_analysis.tools.transitive_code_search.DocumentEmbedding") as mock_de:
             mock_get_coc.return_value = MagicMock()
             _build_searcher(si, "pkg,Func", _DEFAULT_THRESHOLD)
-            mock_de.assert_called_once_with(embedding=None)
+            mock_de.assert_called_once_with(
+                embedding=None,
+                ecosystem=None,
+                manifest_relative_path=None,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/vuln_analysis/tools/tests/test_concurrency.py
+++ b/src/vuln_analysis/tools/tests/test_concurrency.py
@@ -141,7 +141,7 @@ def _make_slow_builder(build_log, sleep_secs=0.2, java=True):
     """
     lock = threading.Lock()
 
-    def slow_build(si, query, uber_jar_file_threshold=_DEFAULT_THRESHOLD,base_dirs=()):
+    def slow_build(si, query, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=()):
         tag = query.split(",")[0]
         start = time.monotonic()
         time.sleep(sleep_secs)
@@ -258,7 +258,7 @@ async def test_different_repos_can_build_concurrently():
     si_b = _make_si("https://github.com/example/repo-b")
     build_log = []
 
-    def slow_build(si, query, uber_jar_file_threshold=_DEFAULT_THRESHOLD,base_dirs=()):
+    def slow_build(si, query, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=()):
         tag = si[0].git_repo.split("/")[-1]
         start = time.monotonic()
         time.sleep(0.2)
@@ -290,7 +290,7 @@ async def test_same_key_deduplicates_build():
     build_count = 0
     count_lock = threading.Lock()
 
-    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD,base_dirs=()):
+    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=()):
         nonlocal build_count
         with count_lock:
             build_count += 1
@@ -321,7 +321,7 @@ async def test_cache_hit_skips_build():
 
     build_count = 0
 
-    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD,base_dirs=()):
+    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=())):
         nonlocal build_count
         build_count += 1
         return _make_nonjava_searcher()
@@ -347,7 +347,7 @@ async def test_java_cache_hit_skips_build():
 
     build_count = 0
 
-    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD,base_dirs=()):
+    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=())):
         nonlocal build_count
         build_count += 1
         return _make_java_searcher()
@@ -369,7 +369,7 @@ async def test_build_failure_cleans_up_building_marker():
     full_key = ("https://github.com/example/repo", "main", "pkg-a:art-a:1.0")
     repo_key = ("https://github.com/example/repo", "main")
 
-    def failing_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD,base_dirs=()):
+    def failing_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=()):
         raise RuntimeError("Maven failed")
 
     with patch("vuln_analysis.tools.transitive_code_search._build_searcher",
@@ -396,7 +396,7 @@ async def test_java_repo_lock_recheck_avoids_redundant_build():
     build_count = 0
     count_lock = threading.Lock()
 
-    def build_that_precaches_b(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD,base_dirs=()):
+    def build_that_precaches_b(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=()):
         nonlocal build_count
         with count_lock:
             build_count += 1
@@ -431,7 +431,7 @@ async def test_nonjava_same_repo_different_packages_share_cache():
     build_count = 0
     count_lock = threading.Lock()
 
-    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD,base_dirs=()):
+    def counting_build(build_si, q, uber_jar_file_threshold=_DEFAULT_THRESHOLD, ecosystem=None, manifest_path=None, base_dirs=()):
         nonlocal build_count
         with count_lock:
             build_count += 1

--- a/src/vuln_analysis/tools/transitive_code_search.py
+++ b/src/vuln_analysis/tools/transitive_code_search.py
@@ -246,14 +246,15 @@ def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem: Eco
     if len(base_dirs) == 2:
         git_base_dir_config, pickle_base_dir_config = base_dirs
         documents_embedder = DocumentEmbedding(
-            embedding=None,
+            embedding=None,           
             pickle_cache_directory=pickle_base_dir_config,
             git_directory=git_base_dir_config,
+            ecosystem=ecosystem, manifest_path=manifest_path
         )
     else:
-        documents_embedder = DocumentEmbedding(embedding=None)
+        documents_embedder = DocumentEmbedding(embedding=None, ecosystem=ecosystem, manifest_path=manifest_path)
 
-    coc_retriever = get_call_of_chains_retriever(documents_embedder, si, query, uber_jar_file_threshold)
+    coc_retriever = get_call_of_chains_retriever(documents_embedder, si, query, uber_jar_file_threshold, ecosystem, manifest_path)
     return TransitiveCodeSearcher(chain_of_calls_retriever=coc_retriever)
 
 

--- a/src/vuln_analysis/tools/transitive_code_search.py
+++ b/src/vuln_analysis/tools/transitive_code_search.py
@@ -157,7 +157,7 @@ class FunctionLibraryVersionFinderToolConfig(FunctionBaseConfig, name=FUNCTION_L
 
 
 
-def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None, manifest_path : str | None):
+def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None, manifest_relative_path : str | None):
     documents: list[Document]
     git_repo = None
     code_source_info: SourceDocumentsInfo
@@ -170,18 +170,22 @@ def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_fi
         raise ValueError("No code source info found")
 
     if not ecosystem:
-        with open(os.path.join(git_repo, 'ecosystem_data.txt'), 'r', encoding='utf-8') as file:
+        path_to_ecosystem_data_file = git_repo
+        if manifest_relative_path:
+            path_to_ecosystem_data_file = os.path.join(git_repo, manifest_relative_path)
+        with open(os.path.join(path_to_ecosystem_data_file, 'ecosystem_data.txt'), 'r', encoding='utf-8') as file:
             ecosystem = file.read()
             ecosystem = Ecosystem[ecosystem.upper()]
 
-    git_repo_with_manifest = resolve_path_to_manifest(git_repo, manifest_path)
-    logger.debug("Manifest path: %s", manifest_path)
+    git_repo_with_manifest = resolve_path_to_manifest(git_repo, manifest_relative_path)
+    logger.debug("Manifest relative path: %s", manifest_relative_path)
     coc_retriever = get_chain_of_calls_retriever(ecosystem=ecosystem,
                                                  documents=documents,
                                                  manifest_path=git_repo_with_manifest,
                                                  query=query,
                                                  code_source_info=code_source_info,
-                                                 uber_jar_file_threshold=uber_jar_file_threshold)
+                                                 uber_jar_file_threshold=uber_jar_file_threshold,
+                                                 manifest_relative_path=manifest_relative_path)
     # Release the raw documents list — the retriever has classified and indexed
     # them into its own structures.  Dropping this reference allows the GC to
     # reclaim any Document objects not retained by the retriever's indexes.
@@ -206,7 +210,7 @@ async def _get_repo_lock(si) -> asyncio.Lock:
         return _repo_build_locks[repo_key]
 
 
-def _get_cache_keys(si, query: str, manifest_path: str) -> tuple[tuple | None, tuple | None]:
+def _get_cache_keys(si, query: str, manifest_relative_path: str | None = None) -> tuple[tuple | None, tuple | None]:
     """Derive cache keys from source_info list.
 
     Returns (repo_key, full_key):
@@ -218,10 +222,10 @@ def _get_cache_keys(si, query: str, manifest_path: str) -> tuple[tuple | None, t
     """
     for source_info in si:
         if source_info.type == "code":
-            if not manifest_path:
+            if not manifest_relative_path:
                 git_repo_path = source_info.git_repo
             else:
-                git_repo_path = f"{source_info.git_repo}/{manifest_path}"
+                git_repo_path = f"{source_info.git_repo}/{manifest_relative_path}"
             repo_key = (git_repo_path, source_info.ref)
             package_name = query.split(",")[0].strip() if query else ""
             full_key = (git_repo_path, source_info.ref, package_name)
@@ -230,7 +234,7 @@ def _get_cache_keys(si, query: str, manifest_path: str) -> tuple[tuple | None, t
     return None, None
 
 
-def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None = None, manifest_path : str | None = None, base_dirs : tuple = ()) -> TransitiveCodeSearcher:
+def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None = None, manifest_relative_path : str | None = None, base_dirs : tuple = ()) -> TransitiveCodeSearcher:
     """Synchronous helper that builds a TransitiveCodeSearcher.
 
     Separated so it can be offloaded to a thread via asyncio.to_thread(),
@@ -245,16 +249,16 @@ def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem: Eco
             embedding=None,           
             pickle_cache_directory=pickle_base_dir_config,
             git_directory=git_base_dir_config,
-            ecosystem=ecosystem, manifest_path=manifest_path
+            ecosystem=ecosystem, manifest_relative_path=manifest_relative_path
         )
     else:
-        documents_embedder = DocumentEmbedding(embedding=None, ecosystem=ecosystem, manifest_path=manifest_path)
+        documents_embedder = DocumentEmbedding(embedding=None, ecosystem=ecosystem, manifest_relative_path=manifest_relative_path)
 
-    coc_retriever = get_call_of_chains_retriever(documents_embedder, si, query, uber_jar_file_threshold, ecosystem, manifest_path)
+    coc_retriever = get_call_of_chains_retriever(documents_embedder, si, query, uber_jar_file_threshold, ecosystem, manifest_relative_path)
     return TransitiveCodeSearcher(chain_of_calls_retriever=coc_retriever)
 
 
-async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None = None, manifest_path : str | None = None, base_dirs: tuple = ()) -> TransitiveCodeSearcher:
+async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None = None, manifest_relative_path : str | None = None, base_dirs: tuple = ()) -> TransitiveCodeSearcher:
     """Build a TransitiveCodeSearcher, or return a cached one.
 
     Cache keys:
@@ -272,7 +276,7 @@ async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, eco
     - The expensive build runs in a thread via asyncio.to_thread().
     :param base_dirs: a tuple contains base dirs of cache - (git_base_dir, pickle_base_dir)
     """
-    repo_key, full_key = _get_cache_keys(si, query, manifest_path)
+    repo_key, full_key = _get_cache_keys(si, query, manifest_relative_path)
 
     while True:
         async with _searcher_cache_lock:
@@ -328,7 +332,7 @@ async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, eco
                 # other tasks can read/write the cache while this build runs,
                 # but no concurrent build on the same repo's filesystem.
                 logger.info("Building TransitiveCodeSearcher for %s", full_key)
-                searcher = await asyncio.to_thread(_build_searcher, si, query, uber_jar_file_threshold, ecosystem, manifest_path, base_dirs)
+                searcher = await asyncio.to_thread(_build_searcher, si, query, uber_jar_file_threshold, ecosystem, manifest_relative_path, base_dirs)
 
             async with _searcher_cache_lock:
                 # Cache under the appropriate key based on ecosystem
@@ -365,22 +369,22 @@ async def get_transitive_code_searcher(query: str, base_dirs: tuple):
     si = state.original_input.input.image.source_info
     threshold = state.uber_jar_file_threshold
     ecosystem = state.original_input.input.image.ecosystem
-    manifest_path = state.original_input.input.image.manifest_path
+    manifest_relative_path = state.original_input.input.image.manifest_path
 
     if state.transitive_code_searcher is None:
-        state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, ecosystem, manifest_path, base_dirs)
+        state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, ecosystem, manifest_relative_path, base_dirs)
     elif isinstance(state.transitive_code_searcher.chain_of_calls_retriever, JavaChainOfCallsRetriever):
         # Java: different queries produce different dep trees (build_tree uses
         # -DtargetIncludes for GAV queries), so rebuild when the package changes.
         # Only re-check the cache when the package actually changed to avoid
         # unnecessary lock acquisition on every tool call within the same request.
-        _, full_key = _get_cache_keys(si, query, manifest_path)
+        _, full_key = _get_cache_keys(si, query, manifest_relative_path)
         async with _searcher_cache_lock:
             cached = _searcher_cache.get(full_key)
         if cached is not None and cached is state.transitive_code_searcher:
             pass  # Same searcher, no change needed
         else:
-            state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, ecosystem, manifest_path, base_dirs)
+            state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, ecosystem, manifest_relative_path, base_dirs)
 
     # Both Java and non-Java retrievers use per-search context objects (_JavaSearchCtx / _SearchCtx)
     # for mutable state, so the retriever instance is immutable after __init__ and needs no deep copy.

--- a/src/vuln_analysis/tools/transitive_code_search.py
+++ b/src/vuln_analysis/tools/transitive_code_search.py
@@ -156,7 +156,7 @@ class FunctionLibraryVersionFinderToolConfig(FunctionBaseConfig, name=FUNCTION_L
 
 
 
-def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem, manifest_path : str):
+def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None, manifest_path : str | None):
     documents: list[Document]
     git_repo = None
     code_source_info: SourceDocumentsInfo
@@ -234,8 +234,7 @@ def _get_cache_keys(si, query: str, manifest_path: str) -> tuple[tuple | None, t
     return None, None
 
 
-
-def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem, manifest_path : str, base_dirs : tuple = ()) -> TransitiveCodeSearcher:
+def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None = None, manifest_path : str | None = None, base_dirs : tuple = ()) -> TransitiveCodeSearcher:
     """Synchronous helper that builds a TransitiveCodeSearcher.
 
     Separated so it can be offloaded to a thread via asyncio.to_thread(),
@@ -258,7 +257,7 @@ def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem: Eco
     return TransitiveCodeSearcher(chain_of_calls_retriever=coc_retriever)
 
 
-async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem, manifest_path : str, base_dirs: tuple = ()) -> TransitiveCodeSearcher:
+async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem | None = None, manifest_path : str | None = None, base_dirs: tuple = ()) -> TransitiveCodeSearcher:
     """Build a TransitiveCodeSearcher, or return a cached one.
 
     Cache keys:

--- a/src/vuln_analysis/tools/transitive_code_search.py
+++ b/src/vuln_analysis/tools/transitive_code_search.py
@@ -16,6 +16,7 @@ import asyncio
 import os
 from collections import OrderedDict
 
+from exploit_iq_commons.utils.git_utils import resolve_path_to_manifest
 from vuln_analysis.runtime_context import ctx_state
 from exploit_iq_commons.utils.transitive_code_searcher_tool import TransitiveCodeSearcher
 from aiq.builder.builder import Builder
@@ -173,12 +174,7 @@ def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_fi
             ecosystem = file.read()
             ecosystem = Ecosystem[ecosystem.upper()]
 
-    if manifest_path:
-        logger.debug("Appending git repo  manifest path with: %s", manifest_path)
-        git_repo_with_manifest = git_repo.joinpath(manifest_path)
-    else:
-        git_repo_with_manifest = git_repo
-
+    git_repo_with_manifest = resolve_path_to_manifest(git_repo, manifest_path)
     logger.debug("Manifest path: %s", manifest_path)
     coc_retriever = get_chain_of_calls_retriever(ecosystem=ecosystem,
                                                  documents=documents,

--- a/src/vuln_analysis/tools/transitive_code_search.py
+++ b/src/vuln_analysis/tools/transitive_code_search.py
@@ -156,7 +156,7 @@ class FunctionLibraryVersionFinderToolConfig(FunctionBaseConfig, name=FUNCTION_L
 
 
 
-def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_file_threshold: int, ecosystem, manifest_path : str):
+def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem, manifest_path : str):
     documents: list[Document]
     git_repo = None
     code_source_info: SourceDocumentsInfo
@@ -210,7 +210,7 @@ async def _get_repo_lock(si) -> asyncio.Lock:
         return _repo_build_locks[repo_key]
 
 
-def _get_cache_keys(si, query: str) -> tuple[tuple | None, tuple | None]:
+def _get_cache_keys(si, query: str, manifest_path: str) -> tuple[tuple | None, tuple | None]:
     """Derive cache keys from source_info list.
 
     Returns (repo_key, full_key):
@@ -222,10 +222,15 @@ def _get_cache_keys(si, query: str) -> tuple[tuple | None, tuple | None]:
     """
     for source_info in si:
         if source_info.type == "code":
-            repo_key = (source_info.git_repo, source_info.ref)
+            if not manifest_path:
+                git_repo_path = source_info.git_repo
+            else:
+                git_repo_path = f"{source_info.git_repo}/{manifest_path}"
+            repo_key = (git_repo_path, source_info.ref)
             package_name = query.split(",")[0].strip() if query else ""
-            full_key = (source_info.git_repo, source_info.ref, package_name)
+            full_key = (git_repo_path, source_info.ref, package_name)
             return repo_key, full_key
+       
     return None, None
 
 
@@ -270,12 +275,7 @@ async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, eco
     - The expensive build runs in a thread via asyncio.to_thread().
     :param base_dirs: a tuple contains base dirs of cache - (git_base_dir, pickle_base_dir)
     """
-    # TODO: netanel, for simplicity for first revision, do not use cache when using manifest_path
-    if manifest_path:
-        repo_key = None
-        full_key = None
-    else:
-        repo_key, full_key = _get_cache_keys(si, query)
+    repo_key, full_key = _get_cache_keys(si, query, manifest_path)
 
     while True:
         async with _searcher_cache_lock:
@@ -367,34 +367,23 @@ async def get_transitive_code_searcher(query: str, base_dirs: tuple):
     state: AgentMorpheusEngineState = ctx_state.get()
     si = state.original_input.input.image.source_info
     threshold = state.uber_jar_file_threshold
+    ecosystem = state.original_input.input.image.ecosystem
+    manifest_path = state.original_input.input.image.manifest_path
 
-    # TODO: netanel, cache and manifest_path/ecosystem recieved via parameter need to be handled in here as well...
-    if True:
-        state.transitive_code_searcher = await _build_or_get_cached(
-            si, 
-            query,
-            threshold,
-            state.original_input.input.image.ecosystem,
-            state.original_input.input.image.manifest_path)
-
-    # TODO: netanel, the original logic, this code is currently won't ber called, yet - add some changes.
     if state.transitive_code_searcher is None:
-        state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, state.original_input.input.image.ecosystem, state.original_input.input.image.manifest_path, base_dirs)
+        state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, ecosystem, manifest_path, base_dirs)
     elif isinstance(state.transitive_code_searcher.chain_of_calls_retriever, JavaChainOfCallsRetriever):
         # Java: different queries produce different dep trees (build_tree uses
         # -DtargetIncludes for GAV queries), so rebuild when the package changes.
         # Only re-check the cache when the package actually changed to avoid
         # unnecessary lock acquisition on every tool call within the same request.
-        _, full_key = _get_cache_keys(si, query)
+        _, full_key = _get_cache_keys(si, query, manifest_path)
         async with _searcher_cache_lock:
             cached = _searcher_cache.get(full_key)
         if cached is not None and cached is state.transitive_code_searcher:
             pass  # Same searcher, no change needed
         else:
-            state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold,
-                state.original_input.input.image.ecosystem,
-                state.original_input.input.image.manifest_path,
-                base_dirs)
+            state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, ecosystem, manifest_path, base_dirs)
 
     # Both Java and non-Java retrievers use per-search context objects (_JavaSearchCtx / _SearchCtx)
     # for mutable state, so the retriever instance is immutable after __init__ and needs no deep copy.

--- a/src/vuln_analysis/tools/transitive_code_search.py
+++ b/src/vuln_analysis/tools/transitive_code_search.py
@@ -131,7 +131,7 @@ def package_name_from_locator_query(query: str) -> str | None:
     return package or None
 
 
-class TransitiveCodeSearchToolConfig(FunctionBaseConfig, name=("%s" % TRANSITIVE_CODE_SEARCH_TOOL_NAME)):
+class TransitiveCodeSearchToolConfig(FunctionBaseConfig, name=TRANSITIVE_CODE_SEARCH_TOOL_NAME):
     """
     Transitive code search tool used to search source code.
     """
@@ -143,7 +143,7 @@ class CallingFunctionNameExtractorToolConfig(FunctionBaseConfig, name=FUNCTION_N
     """
 
 
-class PackageAndFunctionLocatorToolConfig(FunctionBaseConfig, name=("%s" % PACKAGE_AND_FUNCTION_LOCATOR_TOOL_NAME)):
+class PackageAndFunctionLocatorToolConfig(FunctionBaseConfig, name=PACKAGE_AND_FUNCTION_LOCATOR_TOOL_NAME):
     """
     Package and function locator tool used to validate package names and find function names using fuzzy matching.
     """
@@ -155,7 +155,8 @@ class FunctionLibraryVersionFinderToolConfig(FunctionBaseConfig, name=FUNCTION_L
     """
 
 
-def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_file_threshold: int):
+
+def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_file_threshold: int, ecosystem, manifest_path : str):
     documents: list[Document]
     git_repo = None
     code_source_info: SourceDocumentsInfo
@@ -166,12 +167,22 @@ def get_call_of_chains_retriever(documents_embedder, si, query: str, uber_jar_fi
             documents = documents_embedder.collect_documents(source_info)
     if git_repo is None:
         raise ValueError("No code source info found")
-    with open(os.path.join(git_repo, 'ecosystem_data.txt'), 'r', encoding='utf-8') as file:
-        ecosystem = file.read()
-    ecosystem = Ecosystem[ecosystem]
+
+    if not ecosystem:
+        with open(os.path.join(git_repo, 'ecosystem_data.txt'), 'r', encoding='utf-8') as file:
+            ecosystem = file.read()
+            ecosystem = Ecosystem[ecosystem.upper()]
+
+    if manifest_path:
+        logger.debug("Appending git repo  manifest path with: %s", manifest_path)
+        git_repo_with_manifest = git_repo.joinpath(manifest_path)
+    else:
+        git_repo_with_manifest = git_repo
+
+    logger.debug("Manifest path: %s", manifest_path)
     coc_retriever = get_chain_of_calls_retriever(ecosystem=ecosystem,
                                                  documents=documents,
-                                                 manifest_path=git_repo,
+                                                 manifest_path=git_repo_with_manifest,
                                                  query=query,
                                                  code_source_info=code_source_info,
                                                  uber_jar_file_threshold=uber_jar_file_threshold)
@@ -218,7 +229,7 @@ def _get_cache_keys(si, query: str) -> tuple[tuple | None, tuple | None]:
     return None, None
 
 
-def _build_searcher(si, query: str, uber_jar_file_threshold: int, base_dirs : tuple = ()) -> TransitiveCodeSearcher:
+def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem, manifest_path : str, base_dirs : tuple = ()) -> TransitiveCodeSearcher:
     """Synchronous helper that builds a TransitiveCodeSearcher.
 
     Separated so it can be offloaded to a thread via asyncio.to_thread(),
@@ -241,7 +252,7 @@ def _build_searcher(si, query: str, uber_jar_file_threshold: int, base_dirs : tu
     return TransitiveCodeSearcher(chain_of_calls_retriever=coc_retriever)
 
 
-async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, base_dirs: tuple = ()) -> TransitiveCodeSearcher:
+async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, ecosystem, manifest_path : str, base_dirs: tuple = ()) -> TransitiveCodeSearcher:
     """Build a TransitiveCodeSearcher, or return a cached one.
 
     Cache keys:
@@ -259,7 +270,12 @@ async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, bas
     - The expensive build runs in a thread via asyncio.to_thread().
     :param base_dirs: a tuple contains base dirs of cache - (git_base_dir, pickle_base_dir)
     """
-    repo_key, full_key = _get_cache_keys(si, query)
+    # TODO: netanel, for simplicity for first revision, do not use cache when using manifest_path
+    if manifest_path:
+        repo_key = None
+        full_key = None
+    else:
+        repo_key, full_key = _get_cache_keys(si, query)
 
     while True:
         async with _searcher_cache_lock:
@@ -315,7 +331,7 @@ async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, bas
                 # other tasks can read/write the cache while this build runs,
                 # but no concurrent build on the same repo's filesystem.
                 logger.info("Building TransitiveCodeSearcher for %s", full_key)
-                searcher = await asyncio.to_thread(_build_searcher, si, query, uber_jar_file_threshold, base_dirs)
+                searcher = await asyncio.to_thread(_build_searcher, si, query, uber_jar_file_threshold, ecosystem, manifest_path, base_dirs)
 
             async with _searcher_cache_lock:
                 # Cache under the appropriate key based on ecosystem
@@ -352,8 +368,18 @@ async def get_transitive_code_searcher(query: str, base_dirs: tuple):
     si = state.original_input.input.image.source_info
     threshold = state.uber_jar_file_threshold
 
+    # TODO: netanel, cache and manifest_path/ecosystem recieved via parameter need to be handled in here as well...
+    if True:
+        state.transitive_code_searcher = await _build_or_get_cached(
+            si, 
+            query,
+            threshold,
+            state.original_input.input.image.ecosystem,
+            state.original_input.input.image.manifest_path)
+
+    # TODO: netanel, the original logic, this code is currently won't ber called, yet - add some changes.
     if state.transitive_code_searcher is None:
-        state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, base_dirs)
+        state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, state.original_input.input.image.ecosystem, state.original_input.input.image.manifest_path, base_dirs)
     elif isinstance(state.transitive_code_searcher.chain_of_calls_retriever, JavaChainOfCallsRetriever):
         # Java: different queries produce different dep trees (build_tree uses
         # -DtargetIncludes for GAV queries), so rebuild when the package changes.
@@ -365,7 +391,10 @@ async def get_transitive_code_searcher(query: str, base_dirs: tuple):
         if cached is not None and cached is state.transitive_code_searcher:
             pass  # Same searcher, no change needed
         else:
-            state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold, base_dirs)
+            state.transitive_code_searcher = await _build_or_get_cached(si, query, threshold,
+                state.original_input.input.image.ecosystem,
+                state.original_input.input.image.manifest_path,
+                base_dirs)
 
     # Both Java and non-Java retrievers use per-search context objects (_JavaSearchCtx / _SearchCtx)
     # for mutable state, so the retriever instance is immutable after __init__ and needs no deep copy.

--- a/src/vuln_analysis/tools/transitive_code_search.py
+++ b/src/vuln_analysis/tools/transitive_code_search.py
@@ -234,7 +234,8 @@ def _get_cache_keys(si, query: str, manifest_path: str) -> tuple[tuple | None, t
     return None, None
 
 
-def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem, manifest_path : str, base_dirs : tuple = ()) -> TransitiveCodeSearcher:
+
+def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem, manifest_path : str, base_dirs : tuple = ()) -> TransitiveCodeSearcher:
     """Synchronous helper that builds a TransitiveCodeSearcher.
 
     Separated so it can be offloaded to a thread via asyncio.to_thread(),
@@ -257,7 +258,7 @@ def _build_searcher(si, query: str, uber_jar_file_threshold: int, ecosystem, man
     return TransitiveCodeSearcher(chain_of_calls_retriever=coc_retriever)
 
 
-async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, ecosystem, manifest_path : str, base_dirs: tuple = ()) -> TransitiveCodeSearcher:
+async def _build_or_get_cached(si, query: str, uber_jar_file_threshold: int, ecosystem: Ecosystem, manifest_path : str, base_dirs: tuple = ()) -> TransitiveCodeSearcher:
     """Build a TransitiveCodeSearcher, or return a cached one.
 
     Cache keys:


### PR DESCRIPTION
Enable configuring the manifest path and package ecosystem during a single repository scan. 
This provides the necessary flexibility to target specific sub-projects or services when analyzing a repository within a multi-projects architectural setup. ( mono-repo that contains more than one software project).