### PR TITLE
docs(kustomize): fix OAuth flow — restore oc get route for redirectURIs

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -117,15 +117,24 @@ argilla_api_key=<your_argilla_api_key>
 EOF
 ```
 
-### Step 5. Configure OAuth Authentication
+### Step 5. Configure OAuth Credentials
 
-By default Exploit Intelligence uses OpenShift OAuth for user authentication. The OAuth client secret must be at least 32 bytes (256 bits) because Exploit Intelligence uses it to sign internal session tokens with HS256, which requires a minimum key length of 256 bits.
+Exploit Intelligence uses OpenShift OAuth for user authentication. The OAuth client secret must be at least 32 bytes (256 bits) because Exploit Intelligence uses it to sign internal session tokens with HS256, which requires a minimum key length of 256 bits.
 
-Select the option that matches your situation.
+> [!IMPORTANT]
+> Save the value of `$OAUTH_CLIENT_SECRET` after running the commands below. You need it after deployment to create or update the `OAuthClient` resource.
 
-#### Option A: Create a New OAuthClient
+#### First-Time Deployment
 
-Use this option when deploying Exploit Intelligence for the first time. Generate a new client secret, write the credentials file, and create the `OAuthClient` resource:
+Use this procedure only if no `OAuthClient` named `exploit-iq-client` exists on the cluster. If another Exploit Intelligence installation already uses that `OAuthClient`, you must use the [Reusing an Existing OAuthClient](#reusing-an-existing-oauthclient) procedure instead — generating a new secret overwrites the existing one and breaks authentication for all users of that installation.
+
+Verify that the `OAuthClient` does not exist before proceeding:
+
+```shell
+oc get oauthclient exploit-iq-client 2>&1 | grep -q "not found" && echo "Safe to proceed" || echo "OAuthClient exists — use Reusing an Existing OAuthClient"
+```
+
+Generate a new client secret and write the credentials file:
 
 ```shell
 export OAUTH_CLIENT_SECRET=$(openssl rand -base64 32)
@@ -139,40 +148,12 @@ openshift-domain=$OCP_DOMAIN
 EOF
 ```
 
-```shell
-oc create -f - <<EOF
-apiVersion: oauth.openshift.io/v1
-kind: OAuthClient
-metadata:
-  name: exploit-iq-client
-grantMethod: prompt
-secret: $OAUTH_CLIENT_SECRET
-redirectURIs:
-  - "http://exploit-iq-client:8080"
-  - "https://exploit-iq-client.${YOUR_NAMESPACE_NAME}.apps.${OCP_DOMAIN}"
-  - "http://exploit-iq-client.${YOUR_NAMESPACE_NAME}.apps.${OCP_DOMAIN}"
-EOF
-```
+#### Reusing an Existing OAuthClient
 
-#### Option B: Reuse an Existing OAuthClient
-
-Retrieve the secret from the existing `OAuthClient` resource and verify that it is at least 32 bytes:
+Retrieve the secret from the existing `OAuthClient` resource and write the credentials file:
 
 ```shell
 export OAUTH_CLIENT_SECRET=$(oc get oauthclient exploit-iq-client -o jsonpath='{..secret}')
-echo -n "$OAUTH_CLIENT_SECRET" | wc -c
-```
-
-If the result is less than 32, rotate the secret before continuing:
-
-```shell
-export OAUTH_CLIENT_SECRET=$(openssl rand -base64 32)
-oc patch oauthclient exploit-iq-client -p "{\"secret\":\"$OAUTH_CLIENT_SECRET\"}"
-```
-
-Write the credentials file and add the new redirect URIs to the existing `OAuthClient` resource:
-
-```shell
 export OAUTH_SESSION_SECRET=$(openssl rand -base64 32)
 export OCP_DOMAIN=$(oc whoami --show-server | sed -E 's#^https?://api\.##; s#:[0-9]+/?$##; s#/$##')
 
@@ -181,14 +162,6 @@ client-secret=$OAUTH_CLIENT_SECRET
 session-secret=$OAUTH_SESSION_SECRET
 openshift-domain=$OCP_DOMAIN
 EOF
-```
-
-```shell
-oc patch oauthclient exploit-iq-client -p "{\"redirectURIs\":[
-  \"http://exploit-iq-client:8080\",
-  \"https://exploit-iq-client.${YOUR_NAMESPACE_NAME}.apps.${OCP_DOMAIN}\",
-  \"http://exploit-iq-client.${YOUR_NAMESPACE_NAME}.apps.${OCP_DOMAIN}\"
-]}"
 ```
 
 ### Step 6. Create Database Credentials
@@ -280,6 +253,44 @@ oc kustomize overlays/remote-nim-all | oc apply -f - -n $YOUR_NAMESPACE_NAME
 
 ## Post-Deployment Configuration
 
+### Configure OpenShift OAuth
+
+> [!WARNING]
+> Complete this step before attempting to log in to the Exploit Intelligence UI. Authentication fails if the `OAuthClient` resource is not configured correctly.
+
+After the deployment completes and the `exploit-iq-client` route is available, configure the OpenShift OAuth client. Select the procedure that matches your situation.
+
+#### Create the OAuthClient Resource
+
+Complete this procedure if you followed Step 5, "First-Time Deployment":
+
+```shell
+oc create -f - <<EOF
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: exploit-iq-client
+grantMethod: prompt
+secret: $OAUTH_CLIENT_SECRET
+redirectURIs:
+  - "http://exploit-iq-client:8080"
+  - "https://$(oc get route exploit-iq-client -o jsonpath='{.spec.host}')"
+  - "http://$(oc get route exploit-iq-client -o jsonpath='{.spec.host}')"
+EOF
+```
+
+#### Update an Existing OAuthClient Resource
+
+Complete this procedure if you followed Step 5, "Reusing an Existing OAuthClient":
+
+```shell
+export HTTPS_ROUTE=https://$(oc get route exploit-iq-client -o jsonpath='{.spec.host}')
+export HTTP_ROUTE=http://$(oc get route exploit-iq-client -o jsonpath='{.spec.host}')
+
+oc patch oauthclient exploit-iq-client \
+  -p '{"redirectURIs":["http://exploit-iq-client:8080","'$HTTP_ROUTE'","'$HTTPS_ROUTE'"]}'
+```
+
 ### Grant Users Access to the Exploit Intelligence UI
 
 Access to the Exploit Intelligence UI is controlled by OpenShift group membership. Add users to the `exploit-iq-view` group to grant UI access. Create the group if it does not exist:
@@ -304,15 +315,16 @@ metadata:
 grantMethod: prompt
 secret: $OAUTH_CLIENT_SECRET
 redirectURIs:
-  - "https://exploitiq-mcp-server.${YOUR_NAMESPACE_NAME}.apps.${OCP_DOMAIN}/oauth/callback"
+  - "https://$(oc get route exploitiq-mcp-server -o jsonpath='{.spec.host}')/oauth/callback"
 EOF
 ```
 
 If the resource already exists, add the callback URI:
 
 ```shell
+export MCP_ROUTE=https://$(oc get route exploitiq-mcp-server -o jsonpath='{.spec.host}')/oauth/callback
 oc patch oauthclient exploitiq-mcp-server \
-  -p "{\"redirectURIs\":[\"https://exploitiq-mcp-server.${YOUR_NAMESPACE_NAME}.apps.${OCP_DOMAIN}/oauth/callback\"]}"
+  -p '{"redirectURIs":["'$MCP_ROUTE'"]}'
 ```
 
 Uncomment the OAuth environment variables in `base/exploitiq_mcp_server.yaml` and redeploy:
@@ -650,19 +662,18 @@ grantMethod: prompt
 secret: $OAUTH_CLIENT_SECRET
 redirectURIs:
   - "http://exploit-iq-client:8080"
-  - "https://exploit-iq-client.${PROJECT_NAME}.apps.${OCP_DOMAIN}"
-  - "http://exploit-iq-client.${PROJECT_NAME}.apps.${OCP_DOMAIN}"
+  - "https://$(oc get route exploit-iq-client -o jsonpath='{.spec.host}')"
+  - "http://$(oc get route exploit-iq-client -o jsonpath='{.spec.host}')"
 EOF
 ```
 
 If the resource already exists, add the new route to the redirect URIs:
 
 ```shell
-oc patch oauthclient exploit-iq-client -p "{\"redirectURIs\":[
-  \"http://exploit-iq-client:8080\",
-  \"https://exploit-iq-client.${PROJECT_NAME}.apps.${OCP_DOMAIN}\",
-  \"http://exploit-iq-client.${PROJECT_NAME}.apps.${OCP_DOMAIN}\"
-]}"
+export HTTPS_ROUTE=https://$(oc get route exploit-iq-client -o jsonpath='{.spec.host}')
+export HTTP_ROUTE=http://$(oc get route exploit-iq-client -o jsonpath='{.spec.host}')
+oc patch oauthclient exploit-iq-client \
+  -p '{"redirectURIs":["http://exploit-iq-client:8080","'$HTTP_ROUTE'","'$HTTPS_ROUTE'"]}'
 ```
 
 **9.** Complete this step if you want MCP clients to authenticate with OpenShift OAuth.
@@ -678,15 +689,16 @@ metadata:
 grantMethod: prompt
 secret: $OAUTH_CLIENT_SECRET
 redirectURIs:
-  - "https://exploitiq-mcp-server.${PROJECT_NAME}.apps.${OCP_DOMAIN}/oauth/callback"
+  - "https://$(oc get route exploitiq-mcp-server -o jsonpath='{.spec.host}')/oauth/callback"
 EOF
 ```
 
 If it already exists, add the callback URI:
 
 ```shell
+export MCP_ROUTE=https://$(oc get route exploitiq-mcp-server -o jsonpath='{.spec.host}')/oauth/callback
 oc patch oauthclient exploitiq-mcp-server \
-  -p "{\"redirectURIs\":[\"https://exploitiq-mcp-server.${PROJECT_NAME}.apps.${OCP_DOMAIN}/oauth/callback\"]}"
+  -p '{"redirectURIs":["'$MCP_ROUTE'"]}'
 ```
 
 Then redeploy:


### PR DESCRIPTION
Fixes a structural problem introduced in PR #263 where `OAuthClient` creation was moved to a pre-deploy step using a predictable URL pattern.