### PR TITLE
fix(dep-tree): fix uv export flags, shell redirect arg, and pip freeze command

### DIFF
--- a/src/exploit_iq_commons/utils/dep_tree.py
+++ b/src/exploit_iq_commons/utils/dep_tree.py
@@ -1698,7 +1698,7 @@ class PythonDependencyTreeBuilder(DependencyTreeBuilder):
         for lock_file in (UV_LOCK, POETRY_LOCK):
             if (manifest_path / lock_file).exists():
                 working_dir = manifest_path
-                create_requirements_command = ["uv","export","--format","requirements-txt","no-dev","2>/dev/null"]
+                create_requirements_command = ["uv","export","--format","requirements-txt","--no-dev"]
                 requirements_txt_result = run_command(args=create_requirements_command, cwd=working_dir)
 
                 if requirements_txt_result is not None:
@@ -1710,7 +1710,7 @@ class PythonDependencyTreeBuilder(DependencyTreeBuilder):
         # Project manifests: uv pip install . resolves and installs all declared deps
         for manifest_name in (PYPROJECT_TOML, SETUP_PY, SETUP_CFG):
             if (manifest_path / manifest_name).exists():
-                run_command([ "uv", "pip", "install", "." , "--python" "venv_python"] , cwd=manifest_path)
+                run_command(["uv", "pip", "install", ".", "--python", venv_python], cwd=manifest_path)
                 return manifest_name
 
         # Pipfile: requires pipenv; skip silently if not available
@@ -1735,8 +1735,8 @@ class PythonDependencyTreeBuilder(DependencyTreeBuilder):
 
     def _write_installed_packages(self, manifest_path: Path) -> None:
         """Write a freeze-format snapshot of the venv to installed_packages.txt."""
-        pip_full_path= f"{manifest_path}/{TRANSITIVE_ENV_NAME}/bin/pip"
-        pip_freeze = run_command([pip_full_path,"list","--format=freeze"])
+        venv_python = f"{manifest_path}/{TRANSITIVE_ENV_NAME}/bin/python"
+        pip_freeze = run_command(["uv", "pip", "freeze", "--python", venv_python])
         if pip_freeze:
             (manifest_path / INSTALLED_PACKAGES_FILE).write_text(pip_freeze)
             logger.info("Wrote installed packages snapshot to %s/%s", manifest_path, INSTALLED_PACKAGES_FILE)


### PR DESCRIPTION
Fix three bugs in `PythonDependencyTreeBuilder`:

- `"--python" "venv_python"` was silently merged into `"--pythonvenv_python"` (missing comma)
- `"no-dev"` -> `"--no-dev"` in `uv export` command
- `"2>/dev/null"` passed as a literal argument to `uv` (not a shell redirect) caused `uv export` to always fail
- `bin/pip list --format=freeze` -> `uv pip freeze --python`: `uv venv` does not install `pip` by default, so `bin/pip` never exists