### PR TITLE
chore(deps): remove unused nemollm direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "google-search-results==2.4",
   "json5",
   "nbformat",
-  "nemollm",
   "openinference-instrumentation-langchain~=0.1.31",
   "ordered_set",
   "packageurl-python",

--- a/uv.lock
+++ b/uv.lock
@@ -2730,22 +2730,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nemollm"
-version = "0.3.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-    { name = "requests-futures" },
-    { name = "requests-toolbelt" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/c1/0975d3e7b3293fc4480fe6521ddfcba2a02da131f7751c295430c797e5f8/nemollm-0.3.5-py3-none-any.whl", hash = "sha256:de3962d82d557ce5f3d773144361b897a181028b8e1bbdf94804eff865eead88", size = 11573, upload-time = "2024-01-05T19:46:57.009Z" },
-]
-
-[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4429,18 +4413,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-futures"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/88/f8/175b823241536ba09da033850d66194c372c65c38804847ac9cef0239542/requests_futures-1.0.2.tar.gz", hash = "sha256:6b7eb57940336e800faebc3dab506360edec9478f7b22dc570858ad3aa7458da", size = 10356, upload-time = "2024-11-15T22:14:51.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/23/7c1096731c15c83826cb0dd42078b561a838aed44c36f370aeb815168106/requests_futures-1.0.2-py2.py3-none-any.whl", hash = "sha256:a3534af7c2bf670cd7aa730716e9e7d4386497554f87792be7514063b8912897", size = 7671, upload-time = "2024-11-15T22:14:50.255Z" },
-]
-
-[[package]]
 name = "requests-gssapi"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5396,6 +5368,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp-client-cache" },
     { name = "aioresponses" },
+    { name = "beautifulsoup4" },
     { name = "brotli" },
     { name = "csaf-tool" },
     { name = "cvss" },
@@ -5409,10 +5382,10 @@ dependencies = [
     { name = "koji" },
     { name = "litellm" },
     { name = "nbformat" },
-    { name = "nemollm" },
     { name = "nvidia-nat", extra = ["langchain", "profiling", "telemetry"] },
     { name = "openinference-instrumentation-langchain" },
     { name = "ordered-set" },
+    { name = "packageurl-python" },
     { name = "pydpkg" },
     { name = "rank-bm25" },
     { name = "tantivy" },
@@ -5445,6 +5418,7 @@ requires-dist = [
     { name = "aiofiles" },
     { name = "aiohttp-client-cache", specifier = "==0.11" },
     { name = "aioresponses", specifier = "==0.7.6" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "brotli" },
     { name = "csaf-tool", specifier = "==0.3.2" },
     { name = "cvss", specifier = "==3.6" },
@@ -5458,10 +5432,10 @@ requires-dist = [
     { name = "koji" },
     { name = "litellm", specifier = "<=1.75.8" },
     { name = "nbformat" },
-    { name = "nemollm" },
     { name = "nvidia-nat", extras = ["langchain", "profiling", "telemetry"], specifier = ">=1.2.0rc8,<1.3.0" },
     { name = "openinference-instrumentation-langchain", specifier = "~=0.1.31" },
     { name = "ordered-set" },
+    { name = "packageurl-python" },
     { name = "pydpkg", specifier = "==1.9.4" },
     { name = "rank-bm25", specifier = "==0.2.2" },
     { name = "tantivy", specifier = "==0.22.2" },


### PR DESCRIPTION
- Removed `nemollm` from `pyproject.toml` direct dependencies and `requests-futures` (pulled in solely by `nemollm`) removed automatically

**Reason for removal:**
- `nemollm` is not imported anywhere in `src/` or `tests/`
- The package source is hosted in a private repo, making it unsuitable for open-source build reproducibility
- `uv lock` confirms both packages are fully eliminated from the dependency graph (not retained transitively)

I tested with

- [ ] `uv sync` completes without errors
- [ ] `uv run python -c "import vuln_analysis"` succeeds
- [ ] Entry point loads: `uv run python -c "from importlib.metadata import entry_points; ep = [e for e in entry_points(group='aiq.components') if e.name == 'vuln_analysis'][0]; print(ep.load())"`
- [ ] Existing test suite passes: `uv run pytest -q`