### PR TITLE
fix(intel_utils): rewrite parse_cpe with correct field indexing and escape-aware splitting

### DIFF
--- a/src/vuln_analysis/utils/intel_utils.py
+++ b/src/vuln_analysis/utils/intel_utils.py
@@ -86,6 +86,14 @@ _ECO_MAP = {
     "conan": "c", "c": "c", "cpp": "c", "c++": "c",
 }
 
+_NVD_CPE23_FALLBACK = "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"
+_CPE23_REQUIRED_FIELD_COUNT = 13
+_CPE23_PREFIX = ("cpe", "2.3")
+_CPE23_VENDOR_INDEX = 3
+_CPE23_PRODUCT_INDEX = 4
+_CPE23_VERSION_INDEX = 5
+_CPE23_TARGET_SW_INDEX = 10
+
 
 def update_version(incoming_version, current_version, compare):
     """
@@ -127,26 +135,70 @@ def update_version(incoming_version, current_version, compare):
     return updated
 
 
-def parse_cpe(cpe):
+def _split_cpe_components(cpe: str) -> list[str]:
+    """Split CPE on unescaped colons.
+
+    CPE 2.3 values may contain escaped colons (`\\:`). This parser keeps escaped
+    delimiters inside the same component.
     """
-    Parses a Common Platform Enumeration (CPE) string.
+    parts: list[str] = []
+    current: list[str] = []
+    escaped = False
+
+    for char in cpe:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+
+        if char == "\\":
+            current.append(char)
+            escaped = True
+            continue
+
+        if char == ":":
+            parts.append("".join(current))
+            current = []
+            continue
+
+        current.append(char)
+
+    parts.append("".join(current))
+    return parts
+
+
+def _normalize_cpe_component(component: str | None) -> str | None:
+    """Map wildcard / NA / empty values to None."""
+    if component in (None, "", "*", "-"):
+        return None
+    return component
+
+
+def parse_cpe(cpe: str) -> tuple[str | None, str | None, str | None, str | None]:
+    """
+    Parse an NVD Common Platform Enumeration(CPE) 2.3 criteria string.
 
     Args:
-        cpe (str): The CPE string.
+        cpe (str): The CPE string (`cpe:2.3:...`).
 
     Returns:
-        tuple: A tuple containing the vendor, package, version, and system information.
+        tuple: (vendor, package, version, system/target_sw), with wildcard
+        and NA values normalized to None.
     """
-    vendor, package, version, system = None, None, None, None
-    split_cpe = cpe.split(":")
-    if len(split_cpe) > 3:
-        vendor = split_cpe[3] if split_cpe[3] != "*" and split_cpe[3] != "-" else None
-    if len(split_cpe) > 4:
-        package = split_cpe[4] if split_cpe[4] != "*" and split_cpe[4] != "-" else None
-    if len(split_cpe) > 5:
-        version = split_cpe[5] if split_cpe[5] != "*" and split_cpe[5] != "-" else None
-    if len(split_cpe) > 10:
-        system = split_cpe[10] if split_cpe[10] != "*" and split_cpe[5] != "-" else None
+    if not isinstance(cpe, str) or not cpe:
+        return (None, None, None, None)
+
+    split_cpe = _split_cpe_components(cpe)
+    if len(split_cpe) != _CPE23_REQUIRED_FIELD_COUNT:
+        return (None, None, None, None)
+
+    if (split_cpe[0], split_cpe[1]) != _CPE23_PREFIX:
+        return (None, None, None, None)
+
+    vendor = _normalize_cpe_component(split_cpe[_CPE23_VENDOR_INDEX])
+    package = _normalize_cpe_component(split_cpe[_CPE23_PRODUCT_INDEX])
+    version = _normalize_cpe_component(split_cpe[_CPE23_VERSION_INDEX])
+    system = _normalize_cpe_component(split_cpe[_CPE23_TARGET_SW_INDEX])
     return (vendor, package, version, system)
 
 
@@ -165,7 +217,7 @@ def parse_config_vendors(configurations: list):
         nodes = config.get("nodes", [])
         for node in nodes:
             for cpe_match in node.get("cpeMatch", []):
-                vendor, _, _, _ = parse_cpe(cpe_match.get("criteria", "*:*:*:*:*:*:*:*:*:*:*:*:*"))
+                vendor, _, _, _ = parse_cpe(cpe_match.get("criteria", _NVD_CPE23_FALLBACK))
                 if vendor:
                     vendors.add(vendor.replace("_", " ").title())
     return sorted(vendors)
@@ -188,7 +240,7 @@ def parse(configurations: list):
         nodes = config.get("nodes", [])
         for node in nodes:
             for cpe_match in node.get("cpeMatch", []):
-                vendor, package, version, system = parse_cpe(cpe_match.get("criteria", "*:*:*:*:*:*:*:*:*:*:*:*:*"))
+                vendor, package, version, system = parse_cpe(cpe_match.get("criteria", _NVD_CPE23_FALLBACK))
                 ver_start_exclude = cpe_match.get("versionStartExcluding")
                 ver_start_include = update_version(version, cpe_match.get("versionStartIncluding"), "older")
                 ver_end_include = update_version(version, cpe_match.get("versionEndIncluding"), "newer")

--- a/tests/test_intel_utils.py
+++ b/tests/test_intel_utils.py
@@ -11,6 +11,7 @@ from vuln_analysis.utils.intel_utils import (
     _MAX_RHSA_CANDIDATES,
     extract_functions_from_parsed_patch,
     enrich_vulnerable_functions_from_patch,
+    parse_cpe,
 )
 from vuln_analysis.utils.web_patch_fetcher import ParsedPatch, PatchFile, PatchHunk
 
@@ -169,6 +170,34 @@ class TestExtractFunctionsFromParsedPatchNoiseFilter:
         assert "main" not in funcs
         assert "init" not in funcs
         assert "realFunc" in funcs
+
+
+class TestParseCpe:
+    """Tests for NVD CPE 2.3 parsing."""
+
+    def test_parse_cpe_23_valid(self):
+        parsed = parse_cpe("cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*")
+        assert parsed == ("microsoft", "internet_explorer", "8.0.6001", None)
+
+    def test_parse_cpe_23_target_sw_is_extracted(self):
+        parsed = parse_cpe("cpe:2.3:a:hp:openview_network_manager:7.51:*:*:*:*:linux:*:*")
+        assert parsed == ("hp", "openview_network_manager", "7.51", "linux")
+
+    def test_parse_cpe_23_version_dash_does_not_hide_target_sw(self):
+        parsed = parse_cpe("cpe:2.3:a:hp:insight:-:*:*:*:*:online:*:*")
+        assert parsed == ("hp", "insight", None, "online")
+
+    def test_parse_cpe_23_invalid_prefix_returns_empty_tuple(self):
+        parsed = parse_cpe("cpe:/a:microsoft:internet_explorer:8.0.6001:beta")
+        assert parsed == (None, None, None, None)
+
+    def test_parse_cpe_23_invalid_field_count_returns_empty_tuple(self):
+        parsed = parse_cpe("cpe:2.3:a:microsoft:internet_explorer")
+        assert parsed == (None, None, None, None)
+
+    def test_parse_cpe_23_escaped_colon_is_not_treated_as_delimiter(self):
+        parsed = parse_cpe(r"cpe:2.3:a:vendor:bar\:mumble:1.0:*:*:*:*:*:*:*")
+        assert parsed == ("vendor", r"bar\:mumble", "1.0", None)
 
 
 class TestEnrichVulnerableFunctionsFromPatch:


### PR DESCRIPTION
- Copy-paste bug in `parse_cpe` used `split_cpe[5]` (version) instead of `split_cpe[10]` (target_sw) in the NA guard, silently dropping OS-specific constraints. Unified normalization per [NIST IR 7695](https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf) `6.2.1 Syntax for Formatted String Binding`
- Added targeted tests.