### PR TITLE
Make PAC pipelineruns to survive longer.

### DIFF
--- a/.tekton/on-cm-runner.yaml
+++ b/.tekton/on-cm-runner.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/on-comment: "/test-heavy"
 
     pipelinesascode.tekton.dev/task: "[git-clone, ./.tekton/post-integration-evaluation.yaml]"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "100"
 spec:
   timeouts:
       pipeline: 10h30m0s # Timeout for the entire PipelineRun

--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -15,7 +15,7 @@ metadata:
     pipelinesascode.tekton.dev/task: "[git-clone, ./.tekton/post-integration-evaluation.yaml]"
 
     # How many runs we want to keep.
-    pipelinesascode.tekton.dev/max-keep-runs: "5"
+    pipelinesascode.tekton.dev/max-keep-runs: "100"
 spec:
   timeouts:
     pipeline: 2h30m0s # Timeout for the entire PipelineRun


### PR DESCRIPTION
chore: enlarge PAC max-keep-runs annotation to ensure logs will survive longer