### PR TITLE
build: switch base image from Ubuntu to UBI9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE_URL=nvcr.io/nvidia/base/ubuntu
-ARG BASE_IMAGE_TAG=22.04_20240212
+ARG BASE_IMAGE_URL=registry.redhat.io/ubi9/ubi
+ARG BASE_IMAGE_TAG=9.8-1782841664
 ARG PYTHON_VERSION=3.12
 
 # Specified on the command line with --build-arg VULN_ANALYSIS_VERSION=$(python -m setuptools_scm)
@@ -27,31 +27,25 @@ ARG PYTHON_VERSION
 ARG AGENT_GIT_COMMIT
 ARG AGENT_GIT_TAG
 
-ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    AGENT_GIT_COMMIT=${AGENT_GIT_COMMIT} \
+    AGENT_GIT_TAG=${AGENT_GIT_TAG}
 
-ENV AGENT_GIT_COMMIT=${AGENT_GIT_COMMIT}
-ENV AGENT_GIT_TAG=${AGENT_GIT_TAG}
-
-# System dependencies:
-# - build-essential: Required for compiling Python packages with native C extensions
-#   (e.g., psutil, cryptography, cffi) during `uv sync`. Also needed for libkrb5-dev.
-# - libarchive-tools: Provides bsdtar for extracting RPM/SRPM archives in the checker
-# - libkrb5-dev: Kerberos headers for gssapi Python package (Brew authentication)
-RUN apt-get update && apt-get install -y \
-      build-essential \
+RUN dnf install -y --nodocs \
+      bsdtar \
       ca-certificates \
-      curl \
+      gcc \
+      gcc-c++ \
       git \
       git-lfs \
-      wget \
+      krb5-devel \
+      libatomic \
+      make \
       skopeo \
-      libarchive-tools \
-      xz-utils \
-      libatomic1 \
-      libkrb5-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && update-ca-certificates
+      wget \
+      xz \
+    && dnf clean all \
+    && update-ca-trust
 
 
 RUN curl -L -X GET https://go.dev/dl/go1.24.1.linux-amd64.tar.gz -o /tmp/go1.24.1.linux-amd64.tar.gz \
@@ -73,8 +67,8 @@ ENV PATH="/opt/nodejs/bin:${PATH}"
 RUN node --version && npm --version
 
 # --- Temurin JDK 22 (amd64/x86_64) ---
-ARG JDK_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.18%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.18_8.tar.gz"
-ARG JDK_DIR="jdk-17.0.18+8"
+ARG JDK_URL="https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_linux_hotspot_22.0.2_9.tar.gz"
+ARG JDK_DIR="jdk-22.0.2+9"
 RUN mkdir -p /opt/jdk \
  && curl -fsSL -o /tmp/jdk.tgz "${JDK_URL}" \
  && tar -C /opt/jdk -xzf /tmp/jdk.tgz \
@@ -94,13 +88,13 @@ ENV PATH="/opt/apache-maven-${MVN_VER}/bin:${PATH}"
 RUN java -version && mvn -v
 
 # Set SSL environment variables
-ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 # Add Tini
-ENV TINI_VERSION=v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+ADD --chmod=755 \
+    --checksum=sha256:93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c \
+    https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
 
 SHELL ["/bin/bash", "-c"]
 
@@ -130,15 +124,11 @@ RUN --mount=type=cache,id=uv_cache,target=/home/user1001/.cache/uv,mode=0775,sha
 USER 1001
 
 # Activate the environment (make it default for subsequent commands)
-# Enivronment variables for the venv
+# Environment variables for the venv
 ENV PATH="/workspace/.venv/bin:/usr/local/go/bin:$PATH"
 
 # Mark all git repos as safe to avoid git errors
-RUN echo $'\
-[safe]\n\
-        directory = *\n\
-'> ~/.gitconfig
-
+RUN git config --global --add safe.directory '*'
 
 # Activate the environment (make it default for subsequent commands)
 RUN echo "source /workspace/.venv/bin/activate" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,9 @@ ENV PATH="/opt/nodejs/bin:${PATH}"
 # Verify Node.js and npm installation
 RUN node --version && npm --version
 
-# --- Temurin JDK 22 (amd64/x86_64) ---
-ARG JDK_URL="https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_linux_hotspot_22.0.2_9.tar.gz"
-ARG JDK_DIR="jdk-22.0.2+9"
+# --- Temurin JDK 17 (amd64/x86_64) ---
+ARG JDK_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.18%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.18_8.tar.gz"
+ARG JDK_DIR="jdk-17.0.18+8"
 RUN mkdir -p /opt/jdk \
  && curl -fsSL -o /tmp/jdk.tgz "${JDK_URL}" \
  && tar -C /opt/jdk -xzf /tmp/jdk.tgz \


### PR DESCRIPTION
Replace Ubuntu-based `Dockerfile` with UBI9 (`registry.redhat.io/ubi9/ubi:9.8-1782841664`)