### PR TITLE
chore(nginx): remove exploit-iq route and add server_tokens off

### DIFF
--- a/kustomize/base/nginx.yaml
+++ b/kustomize/base/nginx.yaml
@@ -144,22 +144,6 @@ spec:
     app: exploit-iq
     component: nginx-cache
 ---
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: exploit-iq
-  annotations:
-    haproxy.router.openshift.io/timeout: 5m
-spec:
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-  port:
-    targetPort: 8080
-  to:
-    kind: Service
-    name: nginx-cache
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kustomize/base/nginx/nginx_cache.conf
+++ b/kustomize/base/nginx/nginx_cache.conf
@@ -7,6 +7,8 @@ events {
 }
 
 http {
+    server_tokens off;
+
     proxy_ssl_server_name on;
 
     proxy_cache_path /server_cache/llm levels=1:2 keys_zone=llm_cache:10m max_size=20g inactive=14d use_temp_path=off;


### PR DESCRIPTION
- Remove the `exploit-iq` OpenShift Route from `kustomize/base/nginx.yaml` (managed separately via Kuadrant or overlay)
- Add `server_tokens off;` to `nginx_cache.conf` to suppress nginx version disclosure in response headers