### PR TITLE
fix: Prevent Agent from crashing under heavy and  time consuming CPU Workloads.

### DIFF
--- a/kustomize/base/exploit_iq_service.yaml
+++ b/kustomize/base/exploit_iq_service.yaml
@@ -66,18 +66,14 @@ spec:
               protocol: TCP
               containerPort: 8080
           livenessProbe:
-            failureThreshold: 24
-            timeoutSeconds: 10
-            periodSeconds: 20
-            httpGet:
-              path: /health
-              port: http
-# If still doing problems under heavy cpu loads and heavy concurrent workloads , kindly uncomment the tcpSocket block below,
-# and comment out the httpGet group as a temporary workaround.
-# Upgrading the agent to python version 3.14 will solve this issue as it will
-# be a real parallel multi-threading environment without GIL ( Global Interpreter Lock) restrictions.
-#           tcpSocket:
-#             port: 8080
+            failureThreshold: 3
+            timeoutSeconds: 5
+            periodSeconds: 30
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - cat /proc/1/status | grep -q '^State:.*[RSDs]'
 
           resources:
             limits:


### PR DESCRIPTION
fix: switch liveness probe from httpGet to exec to prevent pod crashe…

The Python event loop (GIL-bound) cannot serve HTTP /health responses when the CPU is saturated by heavy longterm concurrent workloads, causing the httpGet liveness probe to fail repeatedly and triggering pod restarts. The exec probe checks that PID 1 is still alive via /proc/1/status, which runs outside the Python process and is unaffected by event loop stalls.

This is as good as it gets for now, to make sure the agent pod process is not turning into a zombie process....
Just at least up until the agent will be upgraded to python 3.14.6 that freed from GIL restriction and enables a better concurrency model and true parallalism