### PR TITLE
fix: enable OTLP exporter in mlops and tests overlays

### DIFF
--- a/kustomize/overlays/mlops/exploit-iq-client-otel-patch.yaml
+++ b/kustomize/overlays/mlops/exploit-iq-client-otel-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: exploit-iq-client
+spec:
+  template:
+    spec:
+      containers:
+        - name: exploit-iq-client
+          env:
+            - name: QUARKUS_OTEL_EXPORTER_OTLP_ENABLED
+              value: "true"

--- a/kustomize/overlays/mlops/kustomization.yaml
+++ b/kustomize/overlays/mlops/kustomization.yaml
@@ -8,5 +8,8 @@ resources:
   # Tempo tracing (same namespace as Grafana for non-CI; CI uses grafana-tempo-poc)
   - tempo
 
+patches:
+  - path: exploit-iq-client-otel-patch.yaml
+
 commonAnnotations:
   deployment-specialization: mlops

--- a/kustomize/overlays/tests/exploit-iq-client-otel-patch.yaml
+++ b/kustomize/overlays/tests/exploit-iq-client-otel-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: exploit-iq-client
+spec:
+  template:
+    spec:
+      containers:
+        - name: exploit-iq-client
+          env:
+            - name: QUARKUS_OTEL_EXPORTER_OTLP_ENABLED
+              value: "true"

--- a/kustomize/overlays/tests/kustomization.yaml
+++ b/kustomize/overlays/tests/kustomization.yaml
@@ -51,6 +51,7 @@ commonAnnotations:
 
 patches:
 - path: nginx-patch.yaml
+- path: exploit-iq-client-otel-patch.yaml
 
 # Add agent instance to the tests overlay, with fine grained permissions.
 #- patch: |-


### PR DESCRIPTION
- Add `QUARKUS_OTEL_EXPORTER_OTLP_ENABLED=true` env var to `exploit-iq-client` deployment in `mlops` and `tests` overlays
- Companion to [exploit-iq-client#270](https://github.com/RHEcosystemAppEng/exploit-iq-client/pull/270) which disables OTLP export by default
- Enables trace export only in environments where its available
