### PR TITLE
chore(deps): remove unused dependencies and move aioresponses to dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,26 +11,19 @@ name = "vuln_analysis"
 dynamic = ["version"]
 dependencies = [
   "exploit-iq-commons",
-  "aiohttp-client-cache==0.11",
   "beautifulsoup4>=4.12.0",
-  "aioresponses==0.7.6",
   "nvidia-nat[langchain,profiling,opentelemetry]>=1.2.0rc8,<1.3.0",
   "nvidia-nat-phoenix>=1.2.0rc8,<1.3.0",
-  "aiofiles",
   "brotli",
-  "esprima",
   "cvss==3.6",
   "faiss-cpu==1.9.0",
   "gitpython~=3.1.49",  # CVE-2026-42284, CVE-2026-42215, CVE-2026-44244
   "google-search-results==2.4",
-  "json5",
-  "nbformat",
   "openinference-instrumentation-langchain~=0.1.31",
   "langchain-core~=0.3.85",
   "ordered_set",
   "packageurl-python",
   "pydpkg==1.9.4",
-  "rank_bm25==0.2.2",
   "tantivy==0.22.2",
   "tree-sitter==0.21.3",
   "tree-sitter-languages==1.10.2",
@@ -54,6 +47,7 @@ vuln_analysis = "vuln_analysis.register"
 [dependency-groups]
 # Dependency groups are only for developers to aid in managing dependencies local to a dev machine.
 dev = [
+  "aioresponses==0.7.6",
   "flake8-pyproject~=1.2",
   "flake8~=7.1",
   "isort==5.12.0",

--- a/src/exploit_iq_commons/pyproject.toml
+++ b/src/exploit_iq_commons/pyproject.toml
@@ -9,7 +9,6 @@ description = "Common library for ExploitIQ - shared code for vulnerability anal
 requires-python = ">=3.11,<3.13"
 
 dependencies = [
-    "esprima==4.0.1",
     "GitPython~=3.1.49",  # CVE-2026-42284, CVE-2026-42215, CVE-2026-44244
     "langchain~=0.3.0",
     "langchain-community~=0.3.0",

--- a/src/vuln_analysis/functions/cve_checklist.py
+++ b/src/vuln_analysis/functions/cve_checklist.py
@@ -15,7 +15,6 @@
 
 import asyncio
 
-import pandas as pd
 from aiq.builder.builder import Builder
 from aiq.builder.framework_enum import LLMFrameworkEnum
 from aiq.builder.function_info import FunctionInfo

--- a/uv.lock
+++ b/uv.lock
@@ -119,21 +119,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aiohttp-client-cache"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "attrs" },
-    { name = "itsdangerous" },
-    { name = "url-normalize" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/3e/6c302a45c23c746afc86d1f35d85125815df9273b17cfb3035f3dfe69971/aiohttp_client_cache-0.11.0.tar.gz", hash = "sha256:0766fff4eda05498c7525374a587810dcc2ccb7b256809dde52ae8790a8453eb", size = 61244, upload-time = "2024-02-09T12:50:40.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/2c/2203bdced6b17aef522775521f0fbebc18a62b766b10f419f6ae5c815a2d/aiohttp_client_cache-0.11.0-py3-none-any.whl", hash = "sha256:5b6217bc26a7b3f5f939809b63a66b67658b660809cd38869d7d45066a26d079", size = 31804, upload-time = "2024-02-09T12:50:38.471Z" },
-]
-
-[[package]]
 name = "aioitertools"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -794,12 +779,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
-name = "esprima"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/a1/50fccd68a12bcfc27adfc9969c090286670a9109a0259f3f70943390b721/esprima-4.0.1.tar.gz", hash = "sha256:08db1a876d3c2910db9cfaeb83108193af5411fc3a3a66ebefacd390d21323ee", size = 47021, upload-time = "2018-08-24T13:59:11.374Z" }
-
-[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -822,7 +801,6 @@ name = "exploit-iq-commons"
 version = "0.1.0"
 source = { editable = "src/exploit_iq_commons" }
 dependencies = [
-    { name = "esprima" },
     { name = "gitpython" },
     { name = "langchain" },
     { name = "langchain-community" },
@@ -836,7 +814,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "esprima", specifier = "==4.0.1" },
     { name = "gitpython", specifier = "~=3.1.49" },
     { name = "langchain", specifier = "~=0.3.0" },
     { name = "langchain-community", specifier = "~=0.3.0" },
@@ -891,15 +868,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/53/8c38a874844a8b0fa10dd8adf3836ac154082cf88d3f22b544e9ceea0a15/fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739", size = 296263, upload-time = "2025-06-26T15:29:08.21Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/50/b1222562c6d270fea83e9c9075b8e8600b8479150a18e4516a6138b980d1/fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca", size = 95514, upload-time = "2025-06-26T15:29:06.49Z" },
-]
-
-[[package]]
-name = "fastjsonschema"
-version = "2.21.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
 ]
 
 [[package]]
@@ -1343,15 +1311,6 @@ wheels = [
 ]
 
 [[package]]
-name = "itsdangerous"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
-]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1414,15 +1373,6 @@ wheels = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/12/ae/929aee9619e9eba9015207a9d2c1c54db18311da7eb4dcf6d41ad6f0eb67/json5-0.12.1.tar.gz", hash = "sha256:b2743e77b3242f8d03c143dd975a6ec7c52e2f2afe76ed934e53503dd4ad4990", size = 52191, upload-time = "2025-08-12T19:47:42.583Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/e2/05328bd2621be49a6fed9e3030b1e51a2d04537d3f816d211b9cc53c5262/json5-0.12.1-py3-none-any.whl", hash = "sha256:d9c9b3bc34a5f54d43c35e11ef7cb87d8bdd098c6ace87117a7b7e83e705c1d5", size = 36119, upload-time = "2025-08-12T19:47:41.131Z" },
-]
-
-[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -1480,20 +1430,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513, upload-time = "2025-04-23T12:34:07.418Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437, upload-time = "2025-04-23T12:34:05.422Z" },
-]
-
-[[package]]
-name = "jupyter-core"
-version = "5.8.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "platformdirs" },
-    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/1b/72906d554acfeb588332eaaa6f61577705e9ec752ddb486f302dafa292d9/jupyter_core-5.8.1.tar.gz", hash = "sha256:0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941", size = 88923, upload-time = "2025-05-27T07:38:16.655Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/57/6bffd4b20b88da3800c5d691e0337761576ee688eb01299eae865689d2df/jupyter_core-5.8.1-py3-none-any.whl", hash = "sha256:c28d268fc90fb53f1338ded2eb410704c5449a358406e8a948b75706e24863d0", size = 28880, upload-time = "2025-05-27T07:38:15.137Z" },
 ]
 
 [[package]]
@@ -1959,21 +1895,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
-name = "nbformat"
-version = "5.10.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastjsonschema" },
-    { name = "jsonschema" },
-    { name = "jupyter-core" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
 ]
 
 [[package]]
@@ -2977,18 +2898,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rank-bm25"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/f9579384aa017d8b4c15613f86954b92a95a93d641cc849182467cf0bb3b/rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d", size = 8347, upload-time = "2022-02-16T12:10:52.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/21/f691fb2613100a62b3fa91e9988c991e9ca5b89ea31c0d3152a3210344f9/rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae", size = 8584, upload-time = "2022-02-16T12:10:50.626Z" },
-]
-
-[[package]]
 name = "referencing"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3512,15 +3421,6 @@ wheels = [
 ]
 
 [[package]]
-name = "traitlets"
-version = "5.14.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
-]
-
-[[package]]
 name = "tree-sitter"
 version = "0.21.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3688,18 +3588,6 @@ wheels = [
 ]
 
 [[package]]
-name = "url-normalize"
-version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/ea/780a38c99fef750897158c0afb83b979def3b379aaac28b31538d24c4e8f/url-normalize-1.4.3.tar.gz", hash = "sha256:d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2", size = 6024, upload-time = "2020-10-26T02:07:11.438Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/1c/6c6f408be78692fc850006a2b6dea37c2b8592892534e09996e401efc74b/url_normalize-1.4.3-py2.py3-none-any.whl", hash = "sha256:ec3c301f04e5bb676d333a7fa162fa977ad2ca04b7e652bfc9fac4e405728eed", size = 6804, upload-time = "2020-10-26T02:07:13.218Z" },
-]
-
-[[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3800,24 +3688,18 @@ wheels = [
 name = "vuln-analysis"
 source = { editable = "." }
 dependencies = [
-    { name = "aiofiles" },
-    { name = "aiohttp-client-cache" },
-    { name = "aioresponses" },
     { name = "banks" },
     { name = "beautifulsoup4" },
     { name = "brotli" },
     { name = "csaf-tool" },
     { name = "cvss" },
-    { name = "esprima" },
     { name = "exploit-iq-commons" },
     { name = "faiss-cpu" },
     { name = "gitpython" },
     { name = "google-search-results" },
-    { name = "json5" },
     { name = "jsonschema" },
     { name = "koji" },
     { name = "langchain-core" },
-    { name = "nbformat" },
     { name = "nvidia-nat", extra = ["langchain", "opentelemetry", "profiling"] },
     { name = "nvidia-nat-phoenix" },
     { name = "openinference-instrumentation-langchain" },
@@ -3826,7 +3708,6 @@ dependencies = [
     { name = "pillow" },
     { name = "pydpkg" },
     { name = "python-multipart" },
-    { name = "rank-bm25" },
     { name = "tantivy" },
     { name = "tree-sitter" },
     { name = "tree-sitter-languages" },
@@ -3837,6 +3718,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aioresponses" },
     { name = "flake8" },
     { name = "flake8-pyproject" },
     { name = "isort" },
@@ -3855,24 +3737,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles" },
-    { name = "aiohttp-client-cache", specifier = "==0.11" },
-    { name = "aioresponses", specifier = "==0.7.6" },
     { name = "banks", specifier = "~=2.4.2" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "brotli" },
     { name = "csaf-tool", specifier = "==0.3.2" },
     { name = "cvss", specifier = "==3.6" },
-    { name = "esprima" },
     { name = "exploit-iq-commons", editable = "src/exploit_iq_commons" },
     { name = "faiss-cpu", specifier = "==1.9.0" },
     { name = "gitpython", specifier = "~=3.1.49" },
     { name = "google-search-results", specifier = "==2.4" },
-    { name = "json5" },
     { name = "jsonschema", specifier = ">=4.0.0,<5.0.0" },
     { name = "koji" },
     { name = "langchain-core", specifier = "~=0.3.85" },
-    { name = "nbformat" },
     { name = "nvidia-nat", extras = ["langchain", "opentelemetry", "profiling"], specifier = ">=1.2.0rc8,<1.3.0" },
     { name = "nvidia-nat-phoenix", specifier = ">=1.2.0rc8,<1.3.0" },
     { name = "openinference-instrumentation-langchain", specifier = "~=0.1.31" },
@@ -3881,7 +3757,6 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.3.0,<13.0.0" },
     { name = "pydpkg", specifier = "==1.9.4" },
     { name = "python-multipart", specifier = "~=0.0.32" },
-    { name = "rank-bm25", specifier = "==0.2.2" },
     { name = "tantivy", specifier = "==0.22.2" },
     { name = "tree-sitter", specifier = "==0.21.3" },
     { name = "tree-sitter-languages", specifier = "==1.10.2" },
@@ -3892,6 +3767,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aioresponses", specifier = "==0.7.6" },
     { name = "flake8", specifier = "~=7.1" },
     { name = "flake8-pyproject", specifier = "~=1.2" },
     { name = "isort", specifier = "==5.12.0" },


### PR DESCRIPTION
## Summary

- Remove 6 unused runtime dependencies from `pyproject.toml`: `aiohttp-client-cache`, `aiofiles`, `esprima`, `json5`, `nbformat`, `rank_bm25`
- Remove `esprima` from `exploit_iq_commons/pyproject.toml` (replaced by tree-sitter)
- Move `aioresponses` from `[project].dependencies` to `[dependency-groups].dev` (test-only mock library)
- Remove dead `import pandas as pd` from `cve_checklist.py` (unused import)
- Update `uv.lock` — 10 packages removed including transitive deps of `nbformat` (`fastjsonschema`, `jupyter-core`, `traitlets`, `itsdangerous`, `url-normalize`)

## Evidence

Full static analysis across `src/`, `tests/`, `scripts/`, CI, Dockerfiles, and kustomize manifests confirmed zero imports for all removed packages. `esprima` has an explicit docstring stating it was dropped in favour of tree-sitter. `rank_bm25` is superseded by `tantivy` for lexical search.

## Test plan

- [ ] `health` endpoint returns `{"status":"ok"}` after `uv run aiq serve`
- [ ] Pipeline starts and processes CVEs without import errors
- [ ] `tests/test_serp_api_key_rotation.py` — all 6 tests pass