### PR TITLE
add null guards to intel collection to catch mismatched ecosystem early

### DIFF
--- a/src/vuln_analysis/functions/cve_http_output.py
+++ b/src/vuln_analysis/functions/cve_http_output.py
@@ -232,7 +232,7 @@ async def output_to_http(config: CVEHttpOutputConfig, builder: Builder):  # pyli
         component = message.input.image.name
         component_version = message.input.image.tag
         env_vars = get_filtered_env_vars()
-        intel = message.info.intel[0].model_dump_json(by_alias=True)
+        intel = message.info.intel[0].model_dump_json(by_alias=True) if message.info.intel else ""
         intel_b64 = encode_in_base64(intel)
         agent_config_b64 = encode_in_base64(agent_config.model_dump_json())
         message_output = message.output.model_dump()

--- a/src/vuln_analysis/utils/output_formatter.py
+++ b/src/vuln_analysis/utils/output_formatter.py
@@ -130,6 +130,9 @@ def _add_cve_intel(markdown_content, model_dict: ExploitIqOutput):
     None
         This function modifies `markdown_content` in place.
     """
+    if model_dict.info.intel is None:
+        return
+
     for intel_obj in model_dict.info.intel:
         cve_id = intel_obj.vuln_id
         cve_description = _normalize_content(_get_cve_description(intel_obj))
@@ -501,6 +504,9 @@ def _add_references(markdown_content, model_dict: ExploitIqOutput):
     None
         This function modifies `markdown_content` in place.
     """
+    if model_dict.info.intel is None:
+        return
+
     for intel_obj in model_dict.info.intel:
         cve_id = intel_obj.vuln_id
         markdown_content[cve_id].append(


### PR DESCRIPTION
If for whatever reason a submitted CVE doesn't match the language/ecosystem of the target package, we handle it gracefully instead of a misleading HTTP 500 internal server error.

## Summary

Add null guards in `_add_cve_intel` and `_add_references` to prevent `TypeError` crashes when `clone_and_deps` fails and `info.intel` is never populated.

## Problem

When `clone_and_deps` fails (e.g., due to ecosystem/manifest mismatches), the pipeline skips `fetch_intel`, leaving `model_dict.info.intel = None`. The report generation step in `output_formatter.py` then attempts to iterate over this `None` value, resulting in an unhandled `TypeError: 'NoneType' object is not iterable` that surfaces as an HTTP 500 to the caller.

## Root Cause

`_add_cve_intel` (line 136) and `_add_references` (line 510) both execute `for intel_obj in model_dict.info.intel` without checking whether `info.intel` is `None`. The pipeline's failure path for `clone_and_deps` does not guarantee that `info.intel` is populated before reaching the formatter.

## Fix

Added early-return null guards at the top of both `_add_cve_intel` and `_add_references`:

```python
if model_dict.info.intel is None:
    return
```

When intel data is unavailable, the report is still generated but omits the intel summary and references sections rather than crashing.

## Testing

- Verified across 6 ecosystem-matching CVEs and 15 known ecosystem-mismatched CVEs.
- All runs completed without HTTP 500 errors from this code path.
- Reports for affected CVEs are generated successfully with intel/references sections gracefully omitted.

Attached below is sample output of a ecosystem-mismatched CVE. Previously it would crash the pipeline with HTTP 500 error.
[ad2aa354-ee25-4448-8cf6-87b64529576e_CVE-2025-28162_1.json](https://github.com/user-attachments/files/30110404/ad2aa354-ee25-4448-8cf6-87b64529576e_CVE-2025-28162_1.json)
