### PR TITLE
security: mitigate CVE-2026-15308 by pinning uv to system python3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN dnf install -y --nodocs \
       krb5-devel \
       libatomic \
       make \
+      python3.12 \
+      python3.12-devel \
       skopeo \
       wget \
       xz \
@@ -126,7 +128,7 @@ RUN groupadd workspace-group && \
 # Install the NeMo Agent toolkit package and vuln analysis package
 RUN --mount=type=cache,id=uv_cache,target=/home/user1001/.cache/uv,mode=0775,sharing=locked \
     export SETUPTOOLS_SCM_PRETEND_VERSION=${VULN_ANALYSIS_VERSION} && \
-    uv venv --python ${PYTHON_VERSION} /workspace/.venv && \
+    UV_PYTHON_DOWNLOADS=never uv venv --python /usr/bin/python3.12 /workspace/.venv && \
     uv sync && \
     chown -R :workspace-group /workspace && \
     chmod -R g+wrx /workspace && \


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/APPENG-5678

## Summary
- Install UBI `python3.12`/`python3.12-devel` and create the venv with `UV_PYTHON_DOWNLOADS=never --python /usr/bin/python3.12` so uv does not pull an unpatched CPython (CVE-2026-15308).

## Test plan
- [x] `podman build -f Dockerfile ...` succeeds
- [x] In image: `python -c "from html.parser import HTMLParser; p=HTMLParser(); print('patched' if hasattr(p,'_pending') else 'VULNERABLE')"` → `patched`