### PR TITLE
document supported llm families; added example configs for guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ limitations under the License.
 - [Customizing the Workflow](#customizing-the-workflow)
   - [Customizing the SBOM input](#customizing-the-sbom-input)
   - [Customizing the LLM models](#customizing-the-llm-models)
+    - [Supported LLM families](#supported-llm-families)
     - [Supported LLM APIs](#supported-llm-apis)
     - [Steps to configure an LLM model](#steps-to-configure-an-llm-model)
+  - [Customizing the llm prompt](#customizing-the-llm-prompt)
   - [Customizing the embedding model](#customizing-the-embedding-model)
     - [Steps to configure an alternate embedding provider](#steps-to-configure-an-alternate-embedding-provider)
   - [Customizing the Output](#customizing-the-output)
@@ -861,6 +863,31 @@ In any configuration file, locate the `llms` section to see the current settings
 * `model_name`: specifies the model name within the LLM API. Sets to value of `CHECKLIST_MODEL_NAME` environment variable if set. Otherwise, sets to default checklist model, `meta/llama-3.1-70b-instruct`. This is also applicable to the other LLM models in the workflow, each having their own environment variable for setting the model name. Refer to the LLM API documentation to determine the available models.
 * `temperature`, `max_tokens`, `top_p`, ...: specifies the model parameters. The available parameters can be found in the NeMo Agent Toolkit [NIMModelConfig](https://docs.nvidia.com/aiqtoolkit/latest/api/aiq/llm/nim_llm/index.html). Any non-supported parameters provided in the configuration will be ignored.
 
+#### Supported LLM families
+
+Prompt catalogs exist for Llama, Gemma, and Granite. Family selection is separate from the inference API (`_type`) and `model_name`. See [Customizing the llm prompt](#customizing-the-llm-prompt) for how prompts are organized.
+
+| Family | Default `model_name` | `model_family` | Example config |
+| ------ | -------------------- | -------------- | -------------- |
+| Meta Llama 3.1 70B Instruct (default) | `meta/llama-3.1-70b-instruct` | Auto from `model_name` (optional: `llama`) | [`config.yml`](./src/vuln_analysis/configs/config.yml), [`config-http-openai.yml`](./src/vuln_analysis/configs/config-http-openai.yml), [`config-http-nim.yml`](./src/vuln_analysis/configs/config-http-nim.yml) |
+| Google Gemma 4 31B IT (FP8) | `RedHatAI/gemma-4-31B-it-FP8-block` | `gemma` (required) | [`config-gemma-test.yml`](./src/vuln_analysis/configs/config-gemma-test.yml) |
+| IBM Granite 4.1 30B (FP8) | `ibm-granite/granite-4.1-30b-fp8` | `granite` (required) | [`config-granite-test.yml`](./src/vuln_analysis/configs/config-granite-test.yml) |
+
+**Default (Llama):** use the standard configs and keep `model_name` on a Llama slug (for example `meta/llama-3.1-70b-instruct`). When `model_family` is unset, the family is inferred from `model_name` via `parse_model_name`.
+
+**Gemma / Granite:** start from the matching `config-*-test.yml`, point `NVIDIA_API_BASE` and the `*_MODEL_NAME` environment variables at your endpoint and model, and set `model_family` consistently on the prompt-driven functions (`cve_checklist`, `cve_agent_executor`, `cve_summarize`, and `cve_justify`).
+
+Example (`model_family` on checklist):
+
+```yaml
+cve_checklist:
+  _type: cve_checklist
+  llm_name: checklist_llm
+  model_family: gemma
+```
+
+> **Note:** `model_name` selects the inference model; `model_family` (when set) selects the prompt catalog and overrides auto-detection from `model_name`.
+
 #### Supported LLM APIs
 | Name                                                                                                         | `_type`        | Auth Env Var(s)               | Base URL Env Var(s)                                                             | Proxy Server Route |
 | ------------------------------------------------------------------------------------------------------------ | -------------- | ----------------------------- | ------------------------------------------------------------------------------- | ------------------ |
@@ -881,7 +908,7 @@ In any configuration file, locate the `llms` section to see the current settings
         top_p: 0.01
         max_retries: 5
 ```
-Please note that the prompts have been tuned to work best with the Llama 3.1 70B NIM and that when using other LLM models it may be necessary to adjust the prompting.
+Prompts are tuned per `model_family` (Llama, Gemma, Granite). The default configs target Meta Llama 3.1 70B Instruct (`meta/llama-3.1-70b-instruct`). When switching to Gemma or Granite, use the example configs above and set `model_family` to match; further prompt edits may still be needed for new model versions.
 
 ## Customizing the llm prompt
 ### Overview


### PR DESCRIPTION
Documents the supported LLM families (Llama 3.1 70B, Gemma 4 31B, Granite 4.1 30B), their default model_names, and how to set model_family under Customizing the LLM models.