### PR TITLE
fix few gitconfig errors before cloning repository

### DIFF
--- a/src/exploit_iq_commons/utils/source_code_git_loader.py
+++ b/src/exploit_iq_commons/utils/source_code_git_loader.py
@@ -16,6 +16,7 @@
 import contextlib
 import os
 import tempfile
+import threading
 import typing
 import urllib.parse
 from pathlib import Path
@@ -77,6 +78,7 @@ PathLike = typing.Union[str, os.PathLike]
 
 logger = LoggingFactory.get_agent_logger(__name__)
 
+_gitconfig_lock = threading.Lock()
 
 def _ssh_known_hosts_path() -> Path:
     """Resolve the managed known_hosts path; fail closed if missing or empty.
@@ -261,10 +263,11 @@ class SourceCodeGitLoader(BlobLoader):
 
         # After "RUN git config --global --add safe.directory '*'" was removed from Dockerfile, need to flag the directory that passed all the
         # security checks as a safe directory.
-        global_config = git.config.get_config_path("global")
-        config = git.GitConfigParser(global_config, read_only=False)
-        with config:
-            config.set_value("safe" , "directory", str(self.repo_path.absolute()))
+        with _gitconfig_lock:
+            global_config = git.config.get_config_path("global")
+            config = git.GitConfigParser(global_config, read_only=False)
+            with config:
+                config.add_value("safe", "directory", str(self.repo_path.resolve()))
 
         if not os.path.exists(self.repo_path) and self.clone_url is None:
             raise ValueError(f"Path {self.repo_path} does not exist")

--- a/src/vuln_analysis/tools/tests/test_source_code_git_loader.py
+++ b/src/vuln_analysis/tools/tests/test_source_code_git_loader.py
@@ -1,6 +1,8 @@
 import shutil
+import threading
 from pathlib import Path
 
+import git.config
 import pytest
 
 from exploit_iq_commons.utils.source_code_git_loader import (
@@ -171,3 +173,142 @@ def test_secure_delete_missing_file_is_noop(tmp_path):
     _secure_delete(missing_path)  # should not raise
 
     assert not missing_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: safe.directory handling in load_repo
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_repos(tmp_path):
+    """Create multiple fake repo directories with .git inside."""
+    repos = []
+    for i in range(5):
+        repo_dir = tmp_path / f"repo-{i}"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        repos.append(repo_dir)
+    return repos
+
+
+@pytest.fixture
+def fake_gitconfig(tmp_path, monkeypatch):
+    """Redirect the global gitconfig to a temp file so we don't touch real ~/.gitconfig."""
+    config_path = str(tmp_path / ".gitconfig")
+    monkeypatch.setattr(git.config, "get_config_path",
+                        lambda scope: config_path)
+    return config_path
+
+
+def test_concurrent_load_repo_gitconfig_lock(fake_repos, fake_gitconfig):
+    """Concurrent load_repo calls must not crash on .gitconfig lock contention.
+
+    Reproduces the integration test failure where multiple requests arrive
+    simultaneously and GitPython's GitConfigParser raises:
+        OSError: Lock for file '~/.gitconfig' did already exist
+    """
+    errors = []
+    barrier = threading.Barrier(len(fake_repos))
+
+    def load_one(repo_path):
+        loader = SourceCodeGitLoader(
+            repo_path=repo_path,
+            clone_url=None,
+            ref="main",
+        )
+        try:
+            barrier.wait(timeout=5)
+            loader.load_repo()
+        except OSError as e:
+            if "Lock" in str(e) or "lock" in str(e):
+                errors.append(e)
+            else:
+                raise
+        except Exception:
+            pass
+
+    threads = [threading.Thread(target=load_one, args=(r,))
+               for r in fake_repos]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, (
+        f"{len(errors)} thread(s) hit .gitconfig lock contention: {errors[0]}"
+    )
+
+
+def test_concurrent_load_repo_preserves_all_safe_directories(fake_repos, fake_gitconfig):
+    """All repos must have their own safe.directory entry after concurrent load_repo calls.
+
+    Reproduces the bug where set_value overwrote previous safe.directory entries,
+    leaving only the last repo's path. Subsequent git operations on earlier repos
+    failed with 'dubious ownership'.
+    """
+    barrier = threading.Barrier(len(fake_repos))
+
+    def load_one(repo_path):
+        loader = SourceCodeGitLoader(
+            repo_path=repo_path,
+            clone_url=None,
+            ref="main",
+        )
+        try:
+            barrier.wait(timeout=5)
+            loader.load_repo()
+        except Exception:
+            pass
+
+    threads = [threading.Thread(target=load_one, args=(r,))
+               for r in fake_repos]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    config = git.GitConfigParser(fake_gitconfig, read_only=True)
+    with config:
+        entries = config.get_values("safe", "directory")
+
+    for repo_path in fake_repos:
+        resolved = str(repo_path.resolve())
+        assert resolved in entries, (
+            f"safe.directory missing for {resolved}; entries: {entries}"
+        )
+
+
+def test_safe_directory_resolves_symlinks(tmp_path, fake_gitconfig):
+    """safe.directory must use the resolved (real) path, not the symlink path.
+
+    Reproduces the 'dubious ownership' failure where .cache/am_cache was a
+    symlink to /exploit-iq-data. load_repo wrote the symlink path but git
+    checked the resolved path, so the safe.directory entry didn't match.
+    """
+    real_dir = tmp_path / "real-data" / "git" / "repo"
+    real_dir.mkdir(parents=True)
+    (real_dir / ".git").mkdir()
+
+    symlink_base = tmp_path / "cache"
+    symlink_base.symlink_to(tmp_path / "real-data")
+    symlink_path = symlink_base / "git" / "repo"
+
+    loader = SourceCodeGitLoader(
+        repo_path=symlink_path,
+        clone_url=None,
+        ref="main",
+    )
+    try:
+        loader.load_repo()
+    except Exception:
+        pass
+
+    config = git.GitConfigParser(fake_gitconfig, read_only=True)
+    with config:
+        entries = config.get_values("safe", "directory")
+
+    resolved = str(real_dir.resolve())
+    assert resolved in entries, (
+        f"safe.directory should contain resolved path {resolved}, "
+        f"not symlink path; entries: {entries}"
+    )


### PR DESCRIPTION
fix:Added Lock at module level to wrap the GitConfigParser write
fix: serialize gitconfig writes and resolve symlinks for safe.directory
fix: need to add safe directory one at a time, not override everything with last safe dir.

Signed-off-by: Theodor Mihalache <tmihalac@redhat.com>
Co-authored-by: Zvi Grinberg <zgrinber@redhat.com>