### PR TITLE
fix: include runtime package data for VEX and commons assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ classifiers = ["Programming Language :: Python"]
 [project.entry-points.'aiq.components']
 vuln_analysis = "vuln_analysis.register"
 
+[tool.setuptools.package-data]
+vuln_analysis = ["configs/**/*.json", "configs/**/*.yml", "configs/**/*.yaml"]
+
 [dependency-groups]
 # Dependency groups are only for developers to aid in managing dependencies local to a dev machine.
 dev = [

--- a/src/exploit_iq_commons/pyproject.toml
+++ b/src/exploit_iq_commons/pyproject.toml
@@ -22,3 +22,6 @@ dependencies = [
 [tool.setuptools.packages.find]
 where = [".."]
 include = ["exploit_iq_commons*"]
+
+[tool.setuptools.package-data]
+exploit_iq_commons = ["data/**/*.json"]


### PR DESCRIPTION
## Summary
- **specific due to the Konflux hermetic build**
- include `vuln_analysis` non-Python config assets in wheel installs via `[tool.setuptools.package-data]`
- include `exploit_iq_commons` JSON data assets in wheel installs via `[tool.setuptools.package-data]`
- ensure runtime paths under `site-packages` contain files required for CSAF/VEX generation and commons datasets

## Test plan
- [x] verify `pyproject.toml` contains `vuln_analysis = [\"configs/**/*.json\", \"configs/**/*.yml\", \"configs/**/*.yaml\"]`
- [x] verify `src/exploit_iq_commons/pyproject.toml` contains `exploit_iq_commons = [\"data/**/*.json\"]`
- [ ] build image in downstream and confirm files exist under `.venv/lib/python3.12/site-packages/`

Closes https://redhat.atlassian.net/browse/TC-5483